### PR TITLE
Term merge module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
         "drupal/rest_oai_pmh": "^2.0@beta",
         "drupal/search_api_solr": "^4.2",
         "drupal/taxonomy_manager": "^2.0",
+	"drupal/term_merge": "^2.0@beta",
         "drupal/transliterate_filenames": "^2.0",
         "drupal/twig_tweak": "^3.2",
         "drupal/view_mode_switch": "^2.0",
@@ -60,7 +61,7 @@
         "drupal/drupal": "*",
         "drupal/core": "<=8"
     },
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "prefer-stable": true,
     "config": {
         "discard-changes": "stash",

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "drupal/rest_oai_pmh": "^2.0@beta",
         "drupal/search_api_solr": "^4.2",
         "drupal/taxonomy_manager": "^2.0",
-	"drupal/term_merge": "^2.0@beta",
+	    "drupal/term_merge": "^2.0@beta",
         "drupal/transliterate_filenames": "^2.0",
         "drupal/twig_tweak": "^3.2",
         "drupal/view_mode_switch": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -3991,6 +3991,120 @@
                 "issues": "https://www.drupal.org/project/issues/taxonomy_manager"
             }
         },
+	{
+            "name": "drupal/term_merge",
+            "version": "2.0.0-beta4",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/term_merge.git",
+                "reference": "2.0.0-beta4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/term_merge-2.0.0-beta4.zip",
+                "reference": "2.0.0-beta4",
+                "shasum": "72350295559d0d8173743bcc63e2cd099fc4236f"
+            },
+            "require": {
+                "drupal/core": "^9 || ^10",
+                "drupal/term_reference_change": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.0.0-beta4",
+                    "datestamp": "1665158256",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Beta releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "legolasbo",
+                    "homepage": "https://www.drupal.org/u/legolasbo"
+                },
+                {
+                    "name": "daniel_j",
+                    "homepage": "https://www.drupal.org/u/daniel_j"
+                },
+                {
+                    "name": "daniel_j",
+                    "homepage": "https://www.drupal.org/user/970952"
+                },
+                {
+                    "name": "eli",
+                    "homepage": "https://www.drupal.org/user/49774"
+                },
+                {
+                    "name": "G.I.Joe",
+                    "homepage": "https://www.drupal.org/user/111415"
+                },
+                {
+                    "name": "legolasbo",
+                    "homepage": "https://www.drupal.org/user/2480548"
+                },
+                {
+                    "name": "nylin",
+                    "homepage": "https://www.drupal.org/user/816040"
+                }
+            ],
+            "description": "Allows users to merge taxonomy terms in the same vocabulary together.",
+            "homepage": "https://www.drupal.org/project/term_merge",
+            "support": {
+                "source": "https://git.drupal.org/project/term_merge.git",
+                "issues": "https://www.drupal.org/project/issues/term_merge"
+            }
+        },
+        {
+            "name": "drupal/term_reference_change",
+            "version": "1.0.0-beta1",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/term_reference_change.git",
+                "reference": "8.x-1.0-beta1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/term_reference_change-8.x-1.0-beta1.zip",
+                "reference": "8.x-1.0-beta1",
+                "shasum": "166711a0c8f9c54055250deac7d74f098a25c885"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.0-beta1",
+                    "datestamp": "1592453666",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Beta releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "legolasbo",
+                    "homepage": "https://www.drupal.org/user/2480548"
+                }
+            ],
+            "description": "Allows term references to be changed in bulk.",
+            "homepage": "https://www.drupal.org/project/term_reference_change",
+            "support": {
+                "source": "https://git.drupalcode.org/project/term_reference_change"
+            }
+        },
         {
             "name": "drupal/token",
             "version": "1.11.0",
@@ -11802,10 +11916,11 @@
             "alias_normalized": "1.9999999.9999999.9999999-dev"
         }
     ],
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "stability-flags": {
         "drupal/flysystem": 15,
         "drupal/rest_oai_pmh": 10,
+	"drupal/term_merge": 10,
         "islandora-rdm/islandora_fits": 20
     },
     "prefer-stable": true,

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -96,6 +96,8 @@ module:
   system: 0
   taxonomy: 0
   taxonomy_manager: 0
+  term_merge: 0
+  term_reference_change: 0
   text: 0
   token: 0
   toolbar: 0


### PR DESCRIPTION
This PR installs the Term Merge Drupal module. It's purpose is to allow site administrators to normalize terms that are duplicated.   

Composer.json Changes

        "drupal/term_merge": "^2.0@beta",
        "minimum-stability": "dev",

I had to change the minimum stability because I was getting this error: 

    - drupal/term_merge[2.0.0-beta1, ..., 2.0.0-beta4] require drupal/term_reference_change * -> found drupal/term_reference_change[dev-1.x, 1.0.0-alpha1, 1.0.0-alpha2, 1.0.0 beta1, 1.x-dev (alias of dev-1.x)] but it does not match your minimum-stability. 

    - Root composer.json requires drupal/term_merge ^2.0@beta -> satisfiable by drupal/term_merge[2.0.0-beta1, 2.0.0-beta2, 2.0.0-beta3, 2.0.0-beta4].

Composer.lock Changes

Module | Version
-- | -- |
drupal/term_merge | 2.0.0-beta4 |
drupal/term_reference_change | 1.0.0-beta1 |

At the bottom of the lock file there was a change made to stability from stable to dev and term merge was added to the stability flags. 

Config Changes

    core.extension - added term_merge and term_reference_change so that they are enabled at install

Additional Notes

    I have not tested this at it's limits yet. I need to put together a large list of terms for workbench to migrate in.

How should this be tested?

1. If using isle-dc, replace the starter site repository clone in the starter_dev function of the Makefile with this pr: git clone -b term_merge_module https://github.com/aOelschlager/islandora-starter-site
2. Then run make starter_dev. This should give you a fresh site with the term merge module installed.
3. Upload taxonomy terms.
4. Go to Admin > Structure > Taxonomy > [Vocabulary to edit] > List terms > Merge
5. Check the box or boxes of terms to merge. Ex. imagine, in subject there are two terms news and snews. You would select snews and choose to merge it into an existing term by using the drop drown menu and picking news. Select submit and your incorrect term is now merged into the correct term. 