### PR TITLE
Trivial config updates including reordering yml.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -19,24 +19,24 @@
 *.config  text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
 *.css     text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
 *.dist    text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
-*.engine  text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2 diff=php
+*.engine  text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2 diff=php linguist-language=php
 *.html    text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2 diff=html
-*.inc     text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2 diff=php
-*.install text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2 diff=php
+*.inc     text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2 diff=php linguist-language=php
+*.install text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2 diff=php linguist-language=php
 *.js      text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
 *.json    text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
 *.lock    text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
 *.map     text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
 *.md      text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
-*.module  text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2 diff=php
-*.php     text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2 diff=php
+*.module  text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2 diff=php linguist-language=php
+*.php     text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2 diff=php linguist-language=php
 *.po      text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
-*.profile text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2 diff=php
+*.profile text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2 diff=php linguist-language=php
 *.script  text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
-*.sh      text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2 diff=php
+*.sh      text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2 diff=php linguist-language=php
 *.sql     text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
 *.svg     text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
-*.theme   text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2 diff=php
+*.theme   text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2 diff=php linguist-language=php
 *.twig    text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
 *.txt     text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
 *.xml     text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2

--- a/config/sync/core.entity_form_display.node.islandora_object.default.yml
+++ b/config/sync/core.entity_form_display.node.islandora_object.default.yml
@@ -468,7 +468,7 @@ content:
     region: content
     settings:
       match_operator: CONTAINS
-      size: '60'
+      size: 60
       placeholder: ''
       match_limit: 10
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.taxonomy_term.corporate_body.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.corporate_body.default.yml
@@ -67,7 +67,7 @@ content:
     region: content
     settings:
       match_operator: CONTAINS
-      size: '60'
+      size: 60
       placeholder: ''
     third_party_settings: {  }
   field_type:

--- a/config/sync/core.entity_form_display.taxonomy_term.family.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.family.default.yml
@@ -57,7 +57,7 @@ content:
     region: content
     settings:
       match_operator: CONTAINS
-      size: '60'
+      size: 60
       placeholder: ''
     third_party_settings: {  }
   langcode:

--- a/config/sync/core.entity_form_display.taxonomy_term.person.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.person.default.yml
@@ -68,7 +68,7 @@ content:
     region: content
     settings:
       match_operator: CONTAINS
-      size: '60'
+      size: 60
       placeholder: ''
       match_limit: 10
     third_party_settings: {  }

--- a/config/sync/field.field.node.islandora_object.field_linked_agent.yml
+++ b/config/sync/field.field.node.islandora_object.field_linked_agent.yml
@@ -32,7 +32,7 @@ settings:
     sort:
       field: name
       direction: asc
-    auto_create: 0
+    auto_create: false
     auto_create_bundle: person
   rel_types:
     'relators:asn': ''

--- a/config/sync/field.field.taxonomy_term.corporate_body.field_relationships.yml
+++ b/config/sync/field.field.taxonomy_term.corporate_body.field_relationships.yml
@@ -31,7 +31,7 @@ settings:
     sort:
       field: name
       direction: asc
-    auto_create: 0
+    auto_create: false
     auto_create_bundle: corporate_body
   rel_types:
     'schema:alumni': Alumni

--- a/config/sync/field.field.taxonomy_term.family.field_relationships.yml
+++ b/config/sync/field.field.taxonomy_term.family.field_relationships.yml
@@ -31,7 +31,7 @@ settings:
     sort:
       field: name
       direction: asc
-    auto_create: 0
+    auto_create: false
     auto_create_bundle: corporate_body
   rel_types:
     'schema:member': Member

--- a/config/sync/field.field.taxonomy_term.person.field_relationships.yml
+++ b/config/sync/field.field.taxonomy_term.person.field_relationships.yml
@@ -31,7 +31,7 @@ settings:
     sort:
       field: name
       direction: asc
-    auto_create: 0
+    auto_create: false
     auto_create_bundle: corporate_body
   rel_types:
     'schema:knows': Knows

--- a/config/sync/field.storage.node.field_copyright_date.yml
+++ b/config/sync/field.storage.node.field_copyright_date.yml
@@ -16,9 +16,9 @@ field_name: field_copyright_date
 entity_type: node
 type: edtf
 settings:
-  max_length: '128'
-  is_ascii: false
+  max_length: 128
   case_sensitive: false
+  is_ascii: false
 module: controlled_access_terms
 locked: false
 cardinality: -1

--- a/config/sync/field.storage.node.field_date_captured.yml
+++ b/config/sync/field.storage.node.field_date_captured.yml
@@ -16,9 +16,9 @@ field_name: field_date_captured
 entity_type: node
 type: edtf
 settings:
-  max_length: '128'
-  is_ascii: false
+  max_length: 128
   case_sensitive: false
+  is_ascii: false
 module: controlled_access_terms
 locked: false
 cardinality: -1

--- a/config/sync/field.storage.node.field_date_modified.yml
+++ b/config/sync/field.storage.node.field_date_modified.yml
@@ -16,9 +16,9 @@ field_name: field_date_modified
 entity_type: node
 type: edtf
 settings:
-  max_length: '128'
-  is_ascii: false
+  max_length: 128
   case_sensitive: false
+  is_ascii: false
 module: controlled_access_terms
 locked: false
 cardinality: -1

--- a/config/sync/field.storage.node.field_date_valid.yml
+++ b/config/sync/field.storage.node.field_date_valid.yml
@@ -16,9 +16,9 @@ field_name: field_date_valid
 entity_type: node
 type: edtf
 settings:
-  max_length: '128'
-  is_ascii: false
+  max_length: 128
   case_sensitive: false
+  is_ascii: false
 module: controlled_access_terms
 locked: false
 cardinality: -1

--- a/config/sync/field.storage.node.field_edtf_date.yml
+++ b/config/sync/field.storage.node.field_edtf_date.yml
@@ -12,8 +12,8 @@ entity_type: node
 type: edtf
 settings:
   max_length: 128
-  is_ascii: false
   case_sensitive: false
+  is_ascii: false
 module: core
 locked: false
 cardinality: -1

--- a/config/sync/field.storage.node.field_edtf_date_created.yml
+++ b/config/sync/field.storage.node.field_edtf_date_created.yml
@@ -12,8 +12,8 @@ entity_type: node
 type: edtf
 settings:
   max_length: 128
-  is_ascii: false
   case_sensitive: false
+  is_ascii: false
 module: core
 locked: false
 cardinality: -1

--- a/config/sync/field.storage.node.field_edtf_date_issued.yml
+++ b/config/sync/field.storage.node.field_edtf_date_issued.yml
@@ -12,8 +12,8 @@ entity_type: node
 type: edtf
 settings:
   max_length: 128
-  is_ascii: false
   case_sensitive: false
+  is_ascii: false
 module: core
 locked: false
 cardinality: -1

--- a/config/sync/field.storage.taxonomy_term.field_cat_date_begin.yml
+++ b/config/sync/field.storage.taxonomy_term.field_cat_date_begin.yml
@@ -13,8 +13,8 @@ entity_type: taxonomy_term
 type: edtf
 settings:
   max_length: 60
-  is_ascii: false
   case_sensitive: false
+  is_ascii: false
 module: controlled_access_terms
 locked: false
 cardinality: 1

--- a/config/sync/field.storage.taxonomy_term.field_cat_date_end.yml
+++ b/config/sync/field.storage.taxonomy_term.field_cat_date_end.yml
@@ -13,8 +13,8 @@ entity_type: taxonomy_term
 type: edtf
 settings:
   max_length: 60
-  is_ascii: false
   case_sensitive: false
+  is_ascii: false
 module: controlled_access_terms
 locked: false
 cardinality: 1

--- a/config/sync/rest_oai_pmh.settings.yml
+++ b/config/sync/rest_oai_pmh.settings.yml
@@ -15,10 +15,10 @@ metadata_map_plugins:
     label: oai_dc
     value: dublin_core_rdf
   -
-    label: oai_raw
+    label: mods
     value: ''
   -
-    label: mods
+    label: oai_raw
     value: ''
 cache_technique: liberal_cache
 mods_view:

--- a/config/sync/views.view.newspapers.yml
+++ b/config/sync/views.view.newspapers.yml
@@ -123,6 +123,11 @@ display:
           click_sort_column: value
           type: edtf_default
           settings:
+            date_separator: dash
+            date_order: big_endian
+            month_format: nm
+            day_format: nd
+            year_format: 'y'
             relationship: none
             fieldsets:
               - more
@@ -185,11 +190,6 @@ display:
             click_sort_column: value
             type: edtf_default
             field_api_classes: 0
-            date_separator: dash
-            date_order: big_endian
-            month_format: nm
-            day_format: nd
-            year_format: 'y'
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -252,6 +252,11 @@ display:
           click_sort_column: value
           type: edtf_default
           settings:
+            date_separator: space
+            date_order: big_endian
+            month_format: mmmm
+            day_format: nd
+            year_format: 'y'
             relationship: none
             fieldsets:
               - more
@@ -314,11 +319,6 @@ display:
             click_sort_column: value
             type: edtf_default
             field_api_classes: 0
-            date_separator: space
-            date_order: big_endian
-            month_format: mmmm
-            day_format: nd
-            year_format: 'y'
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -381,6 +381,11 @@ display:
           click_sort_column: value
           type: edtf_default
           settings:
+            date_separator: dash
+            date_order: big_endian
+            month_format: mm
+            day_format: dd
+            year_format: 'y'
             relationship: none
             fieldsets:
               - more
@@ -443,11 +448,6 @@ display:
             click_sort_column: value
             type: edtf_default
             field_api_classes: 0
-            date_separator: dash
-            date_order: big_endian
-            month_format: mm
-            day_format: dd
-            year_format: 'y'
           group_column: value
           group_columns: {  }
           group_rows: true


### PR DESCRIPTION
This brings the starter site in line with what you get when you export the unchanged config from a loaded starter site. Nothing has changed except that the configs now export slightly differently.

* I'm not sure why `linguist-language` snuck in there but it seems to happen both on ISLE and Playbook, so I'm including it.
* A lot of the other changes seem to have to do with improvements to the use of Schemas. e.g. numbers are stored as integers, booleans are stored as boolean. 