### PR TITLE
Add more allowed video formats to video media.

### DIFF
--- a/config/sync/field.field.media.video.field_media_video_file.yml
+++ b/config/sync/field.field.media.video.field_media_video_file.yml
@@ -28,7 +28,7 @@ settings:
   handler: 'default:file'
   handler_settings: {  }
   file_directory: '[date:custom:Y]-[date:custom:m]'
-  file_extensions: 'mp4 mov wmv avi mts flv f4v swf mkv webm ogv'
+  file_extensions: 'mp4 mov wmv avi mts flv f4v swf mkv webm ogv mpeg'
   max_filesize: ''
   description_field: false
 field_type: file

--- a/config/sync/field.field.media.video.field_media_video_file.yml
+++ b/config/sync/field.field.media.video.field_media_video_file.yml
@@ -7,6 +7,11 @@ dependencies:
     - media.type.video
   module:
     - file
+    - filehash
+third_party_settings:
+  filehash:
+    dedupe: 0
+    dedupe_original: false
 _core:
   default_config_hash: aVsH94glMbKDyF_GDPdx83nXIjQmnd9chf7vHN1ApGc
 id: media.video.field_media_video_file
@@ -23,7 +28,7 @@ settings:
   handler: 'default:file'
   handler_settings: {  }
   file_directory: '[date:custom:Y]-[date:custom:m]'
-  file_extensions: mp4
+  file_extensions: 'mp4 mov wmv avi mts flv f4v swf mkv webm ogv'
   max_filesize: ''
   description_field: false
 field_type: file

--- a/config/sync/field.field.node.islandora_object.field_linked_agent.yml
+++ b/config/sync/field.field.node.islandora_object.field_linked_agent.yml
@@ -17,7 +17,7 @@ field_name: field_linked_agent
 entity_type: node
 bundle: islandora_object
 label: 'Linked Agent'
-description: "Names of entities having some relationship to the resource, and, optionally, the relationship to the resource. If a relationship is not specified, it will be recorded as <a href=\"https://id.loc.gov/vocabulary/relators/asn.html\">Associated Name</a> in the system's linked data representation. <br /> \r\n<em>Publisher/manufacturer/distributor/etc. name is recorded here, with the appropriate relationship specified.</em><br />\r\nThis field does not allow creating names of entities on the fly. First create a <a href=\"/admin/structure/taxonomy/manage/person/add\" target=\"_blank\">person</a>, <a href=\"/admin/structure/taxonomy/manage/family/add\" target=\"_blank\">family</a>, or <a href=\"/admin/structure/taxonomy/manage/corporate_body/add\" target=\"_blank\">corporate body</a>, then link it here."
+description: 'Names of entities having some relationship to the resource, and, optionally, the relationship to the resource. If a relationship is not specified, it will be recorded as <a href="https://id.loc.gov/vocabulary/relators/asn.html">Associated Name</a> in the system''s linked data representation. <br /> <em>Publisher/manufacturer/distributor/etc. name is recorded here, with the appropriate relationship specified.</em>'
 required: false
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.node.islandora_object.field_linked_agent.yml
+++ b/config/sync/field.field.node.islandora_object.field_linked_agent.yml
@@ -17,7 +17,7 @@ field_name: field_linked_agent
 entity_type: node
 bundle: islandora_object
 label: 'Linked Agent'
-description: 'Names of entities having some relationship to the resource, and, optionally, the relationship to the resource. If a relationship is not specified, it will be recorded as <a href="https://id.loc.gov/vocabulary/relators/asn.html">Associated Name</a> in the system''s linked data representation. <br /> <em>Publisher/manufacturer/distributor/etc. name is recorded here, with the appropriate relationship specified.</em>'
+description: "Names of entities having some relationship to the resource, and, optionally, the relationship to the resource. If a relationship is not specified, it will be recorded as <a href=\"https://id.loc.gov/vocabulary/relators/asn.html\">Associated Name</a> in the system's linked data representation. <br /> \r\n<em>Publisher/manufacturer/distributor/etc. name is recorded here, with the appropriate relationship specified.</em><br />\r\nThis field does not allow creating names of entities on the fly. First create a <a href=\"/admin/structure/taxonomy/manage/person/add\" target=\"_blank\">person</a>, <a href=\"/admin/structure/taxonomy/manage/family/add\" target=\"_blank\">family</a>, or <a href=\"/admin/structure/taxonomy/manage/corporate_body/add\" target=\"_blank\">corporate body</a>, then link it here."
 required: false
 translatable: false
 default_value: {  }

--- a/config/sync/field.storage.media.field_media_video_file.yml
+++ b/config/sync/field.storage.media.field_media_video_file.yml
@@ -3,8 +3,12 @@ langcode: en
 status: true
 dependencies:
   module:
+    - field_permissions
     - file
     - media
+third_party_settings:
+  field_permissions:
+    permission_type: public
 _core:
   default_config_hash: yR_E-Jhw3fMBrZ0CUXvQs-SO-wzQGFtpa0ELtS3J_U0
 id: media.field_media_video_file


### PR DESCRIPTION
Issue: https://github.com/Islandora-Devops/islandora-starter-site/issues/32

The following file formats have been tested on the Playbook and mp4 service files and thumbnails are created.
* mp4
* mov
* wmv
* mkv
* avi
* mts (AVCHD)
* flv
* f4v
* swf
* webm
* ogv
* mpeg

