### PR TITLE
oai-pmh mods representation (attempt 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,9 @@ In summary: These two messages seem to be ignorable.
 
 #### Patches
 
-There are currently no patches included with the Starter Site. If a patch (external or internal) is necessary, it can be applied automatically by composer by using the [composer-patches plugin](https://github.com/cweagans/composer-patches). Any patches included in the Starter Site should be described fully in this section (including when they should be removed).
+If a patch (external or internal) is necessary, it can be applied automatically by composer by using the [composer-patches plugin](https://github.com/cweagans/composer-patches). Any patches included in the Starter Site should be described fully in this section (including when they should be removed).
+
+* rest_oai_pmh - issue#3283661 - https://www.drupal.org/files/issues/2022-06-01/mods_view_render.patch is being applied to fix an issue related to getting view data into the MODS twig representation.
 
 ### Ongoing Project Maintenance
 

--- a/assets/templates/mods.html.twig
+++ b/assets/templates/mods.html.twig
@@ -1,0 +1,137 @@
+<titleInfo>
+  <title lang="eng">{{ elements.title }}</title>
+  {% if elements.subtitle is not empty%}
+    <subTitle>{{ elements.subtitle }}</subTitle>
+  {% endif %}
+</titleInfo>
+
+{% for role_name_info in elements.linked_agent |split ('|') %}
+{% set role_name = role_name_info|split(':') %}
+{% set name_type_info = elements.linked_agent_vocabulary|split(',') %}
+
+{% set name_type_info_x = name_type_info[loop.index - 1]|replace({"Person":"person"})|raw %}
+{% set name_type_info_x = name_type_info_x|replace({"Corporate Body":"corporate"})|raw %}
+
+<name type="{{ name_type_info_x }}">
+    <role>
+      <roleTerm type="text">{{ role_name[0] }}</roleTerm>
+    </role>
+    <namePart>{{ role_name[1] }}</namePart>
+</name>
+{% endfor %}
+
+<typeOfResource>{{ elements.typeofresource }}</typeOfResource>
+<genre>{{ elements.genre }} </genre>
+<abstract>{{ elements.description }}</abstract>
+<language>
+  {% for language in elements.language_iso6392b |split ('|') %}
+    <languageTerm authority="iso639-2b" type="code">{{ language|trim }}</languageTerm>
+  {% endfor %}
+</language>
+<originInfo>
+  <publisher>{{ elements.publisher }}</publisher>
+  <place>
+    <placeTerm type="text">{{ elements.published_place }}</placeTerm>
+    <placeTerm authority="marccountry">{{ elements.published_place_marccountry }}</placeTerm>
+  </place>
+  <dateCreated keyDate="yes">{{ elements.datecreated_rad14b5 }}</dateCreated>
+  {% if elements.datecreated_start_iso8601 is not empty%}
+    <dateCreated point="start">{{ elements.datecreated_start_iso8601 }}</dateCreated>
+  {% endif %}
+  {% if elements.datecreated_end_iso8601 is not empty%}
+    <dateCreated point="end">{{ elements.datecreated_end_iso8601 }}</dateCreated>
+  {% endif %}
+  <copyrightDate>{{ elements.datecopyright_iso8601 }}</copyrightDate>
+</originInfo>
+<physicalDescription>
+  <form authority="smd">{{ elements.physicaldescription_form }}</form>
+  <extent>{{ elements.physicaldescription_extent }}</extent>
+  <reformattingQuality>{{ elements.physicaldescription_reformatting_quality }}</reformattingQuality>
+  <digitalOrigin>{{ elements.physicaldescription_digitalorigin }}</digitalOrigin>
+  <internetMediaType>{{ elements.physicaldescription_internetmediatype }}</internetMediaType>
+  <note>{{ elements.physicaldescription_note }}</note>
+</physicalDescription>
+<subject authority="local">
+  {% for topic in elements.subject_topic |split ('|') %}
+    <topic>{{ topic|trim }}</topic>
+  {% endfor %}
+  {% for geographic in elements.subject_geographic |split ('|') %}
+    <geographic>{{ geographic|trim }}</geographic>
+  {% endfor %}
+  {% for temporal in elements.subject_temporal |split ('|') %}
+    <temporal>{{ temporal|trim }}</temporal>
+  {% endfor %}
+ 
+  {% set name_type_info = elements.subjects_name_vocabulary|split('|') %}
+  {% for subject_name_info in elements.subjects_name |split ('|') %}
+
+  {% set name_type_info_x = name_type_info[loop.index - 1]|replace({"Person":"person"})|raw %}
+  {% set name_type_info_x = name_type_info_x|replace({"Corporate Body":"corporate"})|raw %}
+
+  <name type="{{ name_type_info_x }}">
+    <namePart>{{ subject_name_info }}</namePart>
+  </name>
+  {% endfor %}
+
+  <hierarchicalGeographic>
+    <continent>{{ elements.subject_hierarchicalgeographic_continent }}</continent>
+    <country>{{ elements.subject_hierarchicalgeographic_country }}</country>
+    <state>{{ elements.subject_hierarchicalgeographic_state }}</state>
+    <province>{{ elements.subject_hierarchicalgeographic_province }}</province>
+    <region>{{ elements.subject_hierarchicalgeographic_region }}</region>
+    <county>{{ elements.subject_hierarchicalgeographic_county }}</county>
+    <island>{{ elements.subject_hierarchicalgeographic_island }}</island>
+    <city>{{ elements.subject_hierarchicalgeographic_city }}</city>
+    <citySection>{{ elements.subject_hierarchicalgeographic_citysection }}</citySection>
+  </hierarchicalGeographic>
+  <cartographics>
+    <coordinates>{{ elements.subject_geographic_coordinates }}</coordinates>
+  </cartographics>
+</subject>
+{% if elements.relateditem_title is not empty %}
+  <relatedItem type="host">
+    <titleInfo>
+      <title>{{ elements.relateditem_title }}</title>
+    </titleInfo>
+  </relatedItem>
+{% endif %}
+{% if elements.relateditem_collection_title is not empty %}
+  <relatedItem type="collection">
+    <titleInfo>
+      <title>{{ elements.relateditem_collection_title }}</title>
+    </titleInfo>
+  </relatedItem>
+{% endif %}
+{% if elements.accesscondition_restrictionandaccess is not empty%}
+  <accessCondition type="restriction and access">{{ elements.accesscondition_restrictionandaccess }}</accessCondition>
+{% endif %}
+<accessCondition type="use and reproduction">{{ elements.accesscondition_useandreproduction }}</accessCondition>
+<location>
+  <url usage="primary display">{{ elements.location_url }}</url>
+  {% if elements.location_physical is not empty %}
+    <physicalLocation>{{ elements.location_physical }}</physicalLocation>
+  {% endif %}
+</location>
+<identifier type="uri">{{ elements.identifier_uri}}</identifier>
+<identifier type="local">{{ elements.identifier_local}}</identifier>
+<identifier type="ark">{{ elements.identifier_ark}}</identifier>
+<note>{{ elements.note }}</note>
+<recordInfo>
+  {% if elements.recordinfo_note_coursecode is not empty %}
+  <recordInfoNote type="courseCode">{{ elements.recordinfo_note_coursecode }}</recordInfoNote>
+  {% endif %}
+  {% if elements.recordinfo_note_courseyear is not empty %}
+    <recordInfoNote type="courseYear">{{ elements.recordinfo_note_courseyear }}</recordInfoNote>
+  {% endif %}
+  {% if elements.recordinfo_note_courseterm is not empty %}
+    <recordInfoNote type="courseTerm">{{ elements.recordinfo_note_courseterm }}</recordInfoNote>
+  {% endif %}
+  <languageOfCataloging>
+  {% if elements.recordinfo_cataloguing_language_iso6392b is not empty %}
+    <languageTerm authority="iso639-2b" type="code">{{ elements.recordinfo_cataloguing_language_iso6392b }}</languageTerm>
+  {% else %}
+    {# Assume language of cataloguing is eng #}
+    <languageTerm authority="iso639-2b" type="code">eng</languageTerm>
+  {% endif %}
+  </languageOfCataloging>
+</recordInfo>

--- a/assets/templates/mods.html.twig
+++ b/assets/templates/mods.html.twig
@@ -9,8 +9,7 @@
 {% set role_name = role_name_info|split(':') %}
 {% set name_type_info = elements.linked_agent_vocabulary|split(',') %}
 
-{% set name_type_info_x = name_type_info[loop.index - 1]|replace({"Person":"person"})|raw %}
-{% set name_type_info_x = name_type_info_x|replace({"Corporate Body":"corporate"})|raw %}
+{% set name_type_info_x = name_type_info[loop.index0]|replace({"Person":"person", "Corporate Body":"corporate", "Family":"family"})|raw %}
 
 <name type="{{ name_type_info_x }}">
     <role>
@@ -61,7 +60,7 @@
   {% for temporal in elements.subject_temporal |split ('|') %}
     <temporal>{{ temporal|trim }}</temporal>
   {% endfor %}
- 
+
   {% set name_type_info = elements.subjects_name_vocabulary|split('|') %}
   {% for subject_name_info in elements.subjects_name |split ('|') %}
 

--- a/composer.json
+++ b/composer.json
@@ -123,6 +123,9 @@
         "patches": {
         }
     },
+    "scripts": {
+        "post-update-cmd": ["cp -f assets/templates/mods.html.twig web/modules/contrib/rest_oai_pmh/templates/mods.html.twig"]
+     },
     "require-dev": {
         "drupal/config_inspector": "^2.1",
         "drupal/devel": "^5.0",

--- a/composer.json
+++ b/composer.json
@@ -121,9 +121,13 @@
             ]
         },
         "patches": {
+            "drupal/rest_oai_pmh": {
+                "View render issue #3283661": "https://www.drupal.org/files/issues/2022-06-01/mods_view_render.patch"
+            }
         }
     },
     "scripts": {
+        "post-install-cmd": ["cp -f assets/templates/mods.html.twig web/modules/contrib/rest_oai_pmh/templates/mods.html.twig"],
         "post-update-cmd": ["cp -f assets/templates/mods.html.twig web/modules/contrib/rest_oai_pmh/templates/mods.html.twig"]
      },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -875,41 +875,36 @@
         },
         {
             "name": "consolidation/output-formatters",
-            "version": "4.2.3",
+            "version": "4.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/output-formatters.git",
-                "reference": "cbb50cc86775f14972003f797b61e232788bee1f"
+                "reference": "b377db7e9435c50c4e019c26ec164b547e754ca0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/output-formatters/zipball/cbb50cc86775f14972003f797b61e232788bee1f",
-                "reference": "cbb50cc86775f14972003f797b61e232788bee1f",
+                "url": "https://api.github.com/repos/consolidation/output-formatters/zipball/b377db7e9435c50c4e019c26ec164b547e754ca0",
+                "reference": "b377db7e9435c50c4e019c26ec164b547e754ca0",
                 "shasum": ""
             },
             "require": {
                 "dflydev/dot-access-data": "^1.1.0 || ^2 || ^3",
                 "php": ">=7.1.3",
-                "symfony/console": "^4|^5|^6",
-                "symfony/finder": "^4|^5|^6"
+                "symfony/console": "^4 || ^5 || ^6",
+                "symfony/finder": "^4 || ^5 || ^6"
             },
             "require-dev": {
                 "php-coveralls/php-coveralls": "^2.4.2",
-                "phpunit/phpunit": ">=7",
+                "phpunit/phpunit": "^7 || ^8 || ^9",
                 "squizlabs/php_codesniffer": "^3",
-                "symfony/var-dumper": "^4|^5|^6",
-                "symfony/yaml": "^4|^5|^6",
-                "yoast/phpunit-polyfills": "^0.2.0"
+                "symfony/var-dumper": "^4 || ^5 || ^6",
+                "symfony/yaml": "^4 || ^5 || ^6",
+                "yoast/phpunit-polyfills": "^1"
             },
             "suggest": {
                 "symfony/var-dumper": "For using the var_dump formatter"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "4.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Consolidation\\OutputFormatters\\": "src"
@@ -928,9 +923,9 @@
             "description": "Format text by applying transformations provided by plug-in formatters.",
             "support": {
                 "issues": "https://github.com/consolidation/output-formatters/issues",
-                "source": "https://github.com/consolidation/output-formatters/tree/4.2.3"
+                "source": "https://github.com/consolidation/output-formatters/tree/4.2.4"
             },
-            "time": "2022-10-17T04:01:40+00:00"
+            "time": "2023-02-24T03:39:10+00:00"
         },
         {
             "name": "consolidation/robo",
@@ -2620,6 +2615,10 @@
                 {
                     "name": "Matthew Grasmick",
                     "homepage": "https://www.drupal.org/user/455714"
+                },
+                {
+                    "name": "markdorison",
+                    "homepage": "https://www.drupal.org/user/346106"
                 }
             ],
             "description": "Provides CSV as a serialization format.",
@@ -12468,5 +12467,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/config/sync/context.context.citation_select_block.yml
+++ b/config/sync/context.context.citation_select_block.yml
@@ -8,7 +8,7 @@ dependencies:
 label: 'Citation Select Block'
 name: citation_select_block
 group: Display
-description: 'On an Islandora nodes (except Collections), show Citation Select Block'
+description: 'If an Islandora node, and not a Collection, show Citation Select Block'
 requireAllConditions: true
 disabled: false
 conditions:

--- a/config/sync/context.context.display_oai_pmh_item_links.yml
+++ b/config/sync/context.context.display_oai_pmh_item_links.yml
@@ -10,7 +10,7 @@ dependencies:
 label: 'Display OAI-PMH Item Links'
 name: display_oai_pmh_item_links
 group: Display
-description: 'If a Repository Item, show OAI-PMH Item Record Links'
+description: 'If an Islandora node, and not a Collection, show OAI-PMH Item Record Links (MODS, DC)'
 requireAllConditions: true
 disabled: false
 conditions:

--- a/config/sync/context.context.display_oai_pmh_item_links.yml
+++ b/config/sync/context.context.display_oai_pmh_item_links.yml
@@ -1,0 +1,55 @@
+uuid: 6aec9511-76fc-43c1-bea6-eb9bab0d990f
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.oai_pmh_item_links
+  module:
+    - islandora
+    - views
+label: 'Display OAI-PMH Item Links'
+name: display_oai_pmh_item_links
+group: Display
+description: 'If a Repository Item, show OAI-PMH Item Record Links'
+requireAllConditions: true
+disabled: false
+conditions:
+  node_has_term:
+    id: node_has_term
+    negate: true
+    uuid: 52390830-adb8-47da-8dca-7017f36377a3
+    context_mapping:
+      node: '@node.node_route_context:node'
+    uri: 'http://purl.org/dc/dcmitype/Collection'
+    logic: and
+  node_is_islandora_object:
+    id: node_is_islandora_object
+    negate: 0
+    uuid: 8f5d786a-c538-4505-b3ad-4c613143d4fd
+    context_mapping:
+      node: '@node.node_route_context:node'
+reactions:
+  blocks:
+    id: blocks
+    uuid: 4fbfa7a6-f1d5-4220-994f-db705a50993b
+    blocks:
+      554b31f0-bd04-420f-aac3-6e3b71889f59:
+        uuid: 554b31f0-bd04-420f-aac3-6e3b71889f59
+        id: 'views_block:oai_pmh_item_links-block_1'
+        label: ''
+        provider: views
+        label_display: visible
+        region: content
+        weight: '0'
+        custom_id: views_block_oai_pmh_item_links_block_1
+        theme: olivero
+        css_class: ''
+        unique: 0
+        context_id: display_oai_pmh_item_links
+        context_mapping: {  }
+        views_label: ''
+        items_per_page: none
+        third_party_settings: {  }
+    include_default_blocks: 0
+    saved: false
+weight: 0

--- a/config/sync/rest_oai_pmh.settings.yml
+++ b/config/sync/rest_oai_pmh.settings.yml
@@ -3,6 +3,7 @@ _core:
 rest_oai_pmh:
   entity_type: node
 view_displays:
+  'oai_pmh:all_repository_items': 'oai_pmh:all_repository_items'
   'oai_pmh:collection_sets': 'oai_pmh:collection_sets'
   'oai_pmh:collectionless_set': 'oai_pmh:collectionless_set'
 support_sets: 1
@@ -12,15 +13,15 @@ repository_email: admin@example.com
 expiration: '3600'
 metadata_map_plugins:
   -
-    label: oai_dc
-    value: dublin_core_rdf
-  -
     label: mods
-    value: ''
+    value: mods
   -
     label: oai_raw
     value: ''
+  -
+    label: oai_dc
+    value: dublin_core_rdf
 cache_technique: liberal_cache
 mods_view:
-  view_machine_name: ''
-  view_display_name: ''
+  view_machine_name: oai_pmh_item_data
+  view_display_name: page_1

--- a/config/sync/search_api.index.default_solr_index.yml
+++ b/config/sync/search_api.index.default_solr_index.yml
@@ -4,11 +4,11 @@ status: true
 dependencies:
   config:
     - field.storage.node.field_alt_title
+    - field.storage.node.field_edtf_date_created
     - field.storage.node.field_member_of
     - field.storage.node.field_description
     - field.storage.node.field_dewey_classification
     - field.storage.node.field_edition
-    - field.storage.node.field_edtf_date_created
     - field.storage.node.field_extent
     - field.storage.node.field_full_title
     - field.storage.node.field_isbn
@@ -18,12 +18,12 @@ dependencies:
     - field.storage.node.field_physical_form
     - field.storage.node.field_resource_type
     - field.storage.node.field_rights
-    - field.storage.node.field_tags
     - field.storage.node.field_subject_general
     - field.storage.node.field_geographic_subject
     - field.storage.node.field_subjects_name
     - field.storage.node.field_temporal_subject
     - field.storage.node.field_subject
+    - field.storage.node.field_tags
     - search_api.server.default_solr_server
     - core.entity_view_mode.node.search_index
   module:
@@ -234,6 +234,16 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.field_tags
+  linked_agent_vid:
+    label: 'Linked Agent Vocab'
+    datasource_id: 'entity:node'
+    property_path: 'field_linked_agent:entity:vid'
+    type: string
+    dependencies:
+      config:
+        - field.storage.node.field_linked_agent
+      module:
+        - taxonomy
   member_of_title:
     label: 'Member of » Content » Title'
     datasource_id: 'entity:node'
@@ -242,6 +252,14 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.field_member_of
+      module:
+        - node
+  nid:
+    label: ID
+    datasource_id: 'entity:node'
+    property_path: nid
+    type: integer
+    dependencies:
       module:
         - node
   node_grants:

--- a/config/sync/views.view.oai_pmh_item_data.yml
+++ b/config/sync/views.view.oai_pmh_item_data.yml
@@ -1,0 +1,1679 @@
+uuid: 297b23af-d1da-41b4-879a-b5344f48944f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_description
+    - field.storage.node.field_edtf_date_issued
+    - field.storage.node.field_genre
+    - field.storage.node.field_geographic_subject
+    - field.storage.node.field_identifier
+    - field.storage.node.field_language
+    - field.storage.node.field_linked_agent
+    - field.storage.node.field_local_identifier
+    - field.storage.node.field_place_published
+    - field.storage.node.field_rights
+    - field.storage.node.field_subject
+    - field.storage.node.field_temporal_subject
+    - search_api.index.default_solr_index
+  module:
+    - controlled_access_terms
+    - search_api
+id: oai_pmh_item_data
+label: 'OAI-PMH Item Data'
+module: views
+description: ''
+tag: ''
+base_table: search_api_index_default_solr_index
+base_field: search_api_id
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'OAI-PMH Item Data'
+      fields:
+        nid:
+          id: nid
+          table: search_api_datasource_default_solr_index_entity_node
+          field: nid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: search_api_field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api_numeric
+          fallback_options:
+            set_precision: false
+            precision: 0
+            decimal: .
+            separator: ','
+            format_plural: false
+            format_plural_string: !!binary MQNAY291bnQ=
+            prefix: ''
+            suffix: ''
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+            format_plural_values:
+              - '1'
+              - '@count'
+        title:
+          id: title
+          table: search_api_datasource_default_solr_index_entity_node
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: search_api_field
+          label: title
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+        field_identifier:
+          id: field_identifier
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_identifier
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: search_api_field
+          label: identifier_uri
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+        field_local_identifier:
+          id: field_local_identifier
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_local_identifier
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: search_api_field
+          label: identifier_local
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+        field_description:
+          id: field_description
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_description
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: search_api_field
+          label: description
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: basic_string
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+        field_genre:
+          id: field_genre
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_genre
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: search_api_field
+          label: genre
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: '|'
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api_entity
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+            display_methods:
+              corporate_body:
+                display_method: label
+                view_mode: default
+              country:
+                display_method: label
+                view_mode: default
+              family:
+                display_method: label
+                view_mode: default
+              frequencies:
+                display_method: label
+                view_mode: default
+              genre:
+                display_method: label
+                view_mode: default
+              geo_location:
+                display_method: label
+                view_mode: default
+              islandora_media_use:
+                display_method: label
+                view_mode: default
+              islandora_models:
+                display_method: label
+                view_mode: default
+              issuance_modes:
+                display_method: label
+                view_mode: default
+              language:
+                display_method: label
+                view_mode: default
+              person:
+                display_method: label
+                view_mode: default
+              physical_form:
+                display_method: label
+                view_mode: default
+              resource_types:
+                display_method: label
+                view_mode: default
+              subject:
+                display_method: label
+                view_mode: default
+              tags:
+                display_method: label
+              temporal_subjects:
+                display_method: label
+                view_mode: default
+        field_resource_type:
+          id: field_resource_type
+          table: search_api_index_default_solr_index
+          field: field_resource_type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_field
+          label: typeofresource
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+        field_edtf_date_issued:
+          id: field_edtf_date_issued
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_edtf_date_issued
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: search_api_field
+          label: datecreated_rad14b5
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: edtf_default
+          settings:
+            date_separator: dash
+            date_order: big_endian
+            month_format: mm
+            day_format: dd
+            year_format: 'y'
+            relationship: none
+            field_rendering: 1
+            fieldsets:
+              - more
+              - admin_label
+            custom_label: 0
+            label: ''
+            element_label_colon: 1
+            exclude: 0
+            element_type_enable: 0
+            element_type: ''
+            element_class_enable: 0
+            element_class: ''
+            element_label_type_enable: 0
+            element_label_type: ''
+            element_label_class_enable: 0
+            element_label_class: ''
+            element_wrapper_type_enable: 0
+            element_wrapper_type: ''
+            element_wrapper_class_enable: 0
+            element_wrapper_class: ''
+            element_default_classes: 1
+            alter:
+              alter_text: 0
+              text: ''
+              make_link: 0
+              path: ''
+              absolute: 0
+              replace_spaces: 0
+              external: 0
+              path_case: none
+              link_class: ''
+              alt: ''
+              rel: ''
+              prefix: ''
+              suffix: ''
+              target: ''
+              trim: 0
+              max_length: '0'
+              word_boundary: 1
+              ellipsis: 1
+              more_link: 0
+              more_link_text: ''
+              more_link_path: ''
+              html: 0
+              strip_tags: 0
+              preserve_tags: ''
+              trim_whitespace: 0
+              nl2br: 0
+            empty: ''
+            empty_zero: 0
+            hide_empty: 0
+            hide_alter_empty: 1
+            group_rows: 1
+            multi_type: separator
+            separator: ', '
+            delta_limit: '0'
+            delta_offset: '0'
+            delta_reversed: 0
+            delta_first_last: 0
+            click_sort_column: value
+            type: edtf_default
+            field_api_classes: 0
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+        field_place_published:
+          id: field_place_published
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_place_published
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: search_api_field
+          label: published_place
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+        field_language:
+          id: field_language
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_language
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: search_api_field
+          label: language_iso6392b
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: '|'
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api_entity
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+            display_methods:
+              corporate_body:
+                display_method: label
+                view_mode: default
+              country:
+                display_method: label
+                view_mode: default
+              family:
+                display_method: label
+                view_mode: default
+              frequencies:
+                display_method: label
+                view_mode: default
+              genre:
+                display_method: label
+                view_mode: default
+              geo_location:
+                display_method: label
+                view_mode: default
+              islandora_media_use:
+                display_method: label
+                view_mode: default
+              islandora_models:
+                display_method: label
+                view_mode: default
+              issuance_modes:
+                display_method: label
+                view_mode: default
+              language:
+                display_method: label
+                view_mode: default
+              person:
+                display_method: label
+                view_mode: default
+              physical_form:
+                display_method: label
+                view_mode: default
+              resource_types:
+                display_method: label
+                view_mode: default
+              subject:
+                display_method: label
+                view_mode: default
+              tags:
+                display_method: label
+              temporal_subjects:
+                display_method: label
+                view_mode: default
+        field_linked_agent:
+          id: field_linked_agent
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_linked_agent
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: search_api_field
+          label: linked_agent
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: typed_relation_default
+          settings:
+            link: false
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+        linked_agent_vid:
+          id: linked_agent_vid
+          table: search_api_index_default_solr_index
+          field: linked_agent_vid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_field
+          label: linked_agent_vocabulary
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api_entity
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+            display_methods:
+              taxonomy_vocabulary:
+                display_method: label
+        field_subject:
+          id: field_subject
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_subject
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: search_api_field
+          label: subject_topic
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: '|'
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api_entity
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+            display_methods:
+              corporate_body:
+                display_method: label
+                view_mode: default
+              country:
+                display_method: label
+                view_mode: default
+              family:
+                display_method: label
+                view_mode: default
+              frequencies:
+                display_method: label
+                view_mode: default
+              genre:
+                display_method: label
+                view_mode: default
+              geo_location:
+                display_method: label
+                view_mode: default
+              islandora_media_use:
+                display_method: label
+                view_mode: default
+              islandora_models:
+                display_method: label
+                view_mode: default
+              issuance_modes:
+                display_method: label
+                view_mode: default
+              language:
+                display_method: label
+                view_mode: default
+              person:
+                display_method: label
+                view_mode: default
+              physical_form:
+                display_method: label
+                view_mode: default
+              resource_types:
+                display_method: label
+                view_mode: default
+              subject:
+                display_method: label
+                view_mode: default
+              tags:
+                display_method: label
+              temporal_subjects:
+                display_method: label
+                view_mode: default
+        field_geographic_subject:
+          id: field_geographic_subject
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_geographic_subject
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: search_api_field
+          label: subject_geographic
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: '|'
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api_entity
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+            display_methods:
+              corporate_body:
+                display_method: label
+                view_mode: default
+              country:
+                display_method: label
+                view_mode: default
+              family:
+                display_method: label
+                view_mode: default
+              frequencies:
+                display_method: label
+                view_mode: default
+              genre:
+                display_method: label
+                view_mode: default
+              geo_location:
+                display_method: label
+                view_mode: default
+              islandora_media_use:
+                display_method: label
+                view_mode: default
+              islandora_models:
+                display_method: label
+                view_mode: default
+              issuance_modes:
+                display_method: label
+                view_mode: default
+              language:
+                display_method: label
+                view_mode: default
+              person:
+                display_method: label
+                view_mode: default
+              physical_form:
+                display_method: label
+                view_mode: default
+              resource_types:
+                display_method: label
+                view_mode: default
+              subject:
+                display_method: label
+                view_mode: default
+              tags:
+                display_method: label
+              temporal_subjects:
+                display_method: label
+                view_mode: default
+        field_temporal_subject:
+          id: field_temporal_subject
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_temporal_subject
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: search_api_field
+          label: subject_temporal
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: '|'
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api_entity
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+            display_methods:
+              corporate_body:
+                display_method: label
+                view_mode: default
+              country:
+                display_method: label
+                view_mode: default
+              family:
+                display_method: label
+                view_mode: default
+              frequencies:
+                display_method: label
+                view_mode: default
+              genre:
+                display_method: label
+                view_mode: default
+              geo_location:
+                display_method: label
+                view_mode: default
+              islandora_media_use:
+                display_method: label
+                view_mode: default
+              islandora_models:
+                display_method: label
+                view_mode: default
+              issuance_modes:
+                display_method: label
+                view_mode: default
+              language:
+                display_method: label
+                view_mode: default
+              person:
+                display_method: label
+                view_mode: default
+              physical_form:
+                display_method: label
+                view_mode: default
+              resource_types:
+                display_method: label
+                view_mode: default
+              subject:
+                display_method: label
+                view_mode: default
+              tags:
+                display_method: label
+              temporal_subjects:
+                display_method: label
+                view_mode: default
+        field_rights:
+          id: field_rights
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_rights
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: search_api_field
+          label: accesscondition_restrictionandaccess
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+      pager:
+        type: mini
+        options:
+          offset: 0
+          items_per_page: 1
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: none
+        options: {  }
+      cache:
+        type: none
+        options: {  }
+      empty: {  }
+      sorts: {  }
+      arguments:
+        nid:
+          id: nid
+          table: search_api_index_default_solr_index
+          field: nid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: node
+          default_argument_options: {  }
+          default_argument_skip_url: false
+          summary_options: {  }
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+      filters:
+        type:
+          id: type
+          table: search_api_index_default_solr_index
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_options
+          operator: or
+          value:
+            islandora_object: islandora_object
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+      style:
+        type: default
+      row:
+        type: fields
+      query:
+        type: search_api_query
+        options:
+          bypass_access: false
+          skip_access: false
+          preserve_facet_query_args: false
+          query_tags: {  }
+      relationships: {  }
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+      tags:
+        - 'config:field.storage.node.field_description'
+        - 'config:field.storage.node.field_edtf_date_issued'
+        - 'config:field.storage.node.field_genre'
+        - 'config:field.storage.node.field_geographic_subject'
+        - 'config:field.storage.node.field_identifier'
+        - 'config:field.storage.node.field_language'
+        - 'config:field.storage.node.field_linked_agent'
+        - 'config:field.storage.node.field_local_identifier'
+        - 'config:field.storage.node.field_place_published'
+        - 'config:field.storage.node.field_rights'
+        - 'config:field.storage.node.field_subject'
+        - 'config:field.storage.node.field_temporal_subject'
+        - 'config:search_api.index.default_solr_index'
+  page_1:
+    id: page_1
+    display_title: Page
+    display_plugin: page
+    position: 1
+    display_options:
+      display_extenders:
+        matomo:
+          enabled: false
+          keyword_gets: ''
+          keyword_behavior: first
+          keyword_concat_separator: ' '
+          category_behavior: none
+          category_gets: ''
+          category_concat_separator: ' '
+          category_fallback: ''
+          category_facets: {  }
+          category_facets_concat_separator: ', '
+      path: mods_info/%node%
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+      tags:
+        - 'config:field.storage.node.field_description'
+        - 'config:field.storage.node.field_edtf_date_issued'
+        - 'config:field.storage.node.field_genre'
+        - 'config:field.storage.node.field_geographic_subject'
+        - 'config:field.storage.node.field_identifier'
+        - 'config:field.storage.node.field_language'
+        - 'config:field.storage.node.field_linked_agent'
+        - 'config:field.storage.node.field_local_identifier'
+        - 'config:field.storage.node.field_place_published'
+        - 'config:field.storage.node.field_rights'
+        - 'config:field.storage.node.field_subject'
+        - 'config:field.storage.node.field_temporal_subject'
+        - 'config:search_api.index.default_solr_index'

--- a/config/sync/views.view.oai_pmh_item_data.yml
+++ b/config/sync/views.view.oai_pmh_item_data.yml
@@ -22,7 +22,7 @@ dependencies:
 id: oai_pmh_item_data
 label: 'OAI-PMH Item Data'
 module: views
-description: ''
+description: 'Generate data used to populate the OAI-PMH MODS Twig Template.'
 tag: ''
 base_table: search_api_index_default_solr_index
 base_field: search_api_id

--- a/config/sync/views.view.oai_pmh_item_data.yml
+++ b/config/sync/views.view.oai_pmh_item_data.yml
@@ -13,7 +13,7 @@ dependencies:
     - field.storage.node.field_local_identifier
     - field.storage.node.field_place_published
     - field.storage.node.field_rights
-    - field.storage.node.field_subject
+    - field.storage.node.field_subject_general
     - field.storage.node.field_temporal_subject
     - search_api.index.default_solr_index
   module:
@@ -980,7 +980,7 @@ display:
           delta_reversed: false
           delta_first_last: false
           multi_type: separator
-          separator: ', '
+          separator: '| '
           field_api_classes: false
           field_rendering: true
           fallback_handler: search_api
@@ -1041,7 +1041,7 @@ display:
           click_sort_column: target_id
           type: entity_reference_label
           settings:
-            link: true
+            link: false
           group_column: target_id
           group_columns: {  }
           group_rows: true
@@ -1062,10 +1062,10 @@ display:
             display_methods:
               taxonomy_vocabulary:
                 display_method: label
-        field_subject:
-          id: field_subject
+        field_subject_general:
+          id: field_subject_general
           table: search_api_datasource_default_solr_index_entity_node
-          field: field_subject
+          field: field_subject_general
           relationship: none
           group_type: group
           admin_label: ''
@@ -1633,7 +1633,7 @@ display:
         - 'config:field.storage.node.field_local_identifier'
         - 'config:field.storage.node.field_place_published'
         - 'config:field.storage.node.field_rights'
-        - 'config:field.storage.node.field_subject'
+        - 'config:field.storage.node.field_subject_general'
         - 'config:field.storage.node.field_temporal_subject'
         - 'config:search_api.index.default_solr_index'
   page_1:
@@ -1674,6 +1674,6 @@ display:
         - 'config:field.storage.node.field_local_identifier'
         - 'config:field.storage.node.field_place_published'
         - 'config:field.storage.node.field_rights'
-        - 'config:field.storage.node.field_subject'
+        - 'config:field.storage.node.field_subject_general'
         - 'config:field.storage.node.field_temporal_subject'
         - 'config:search_api.index.default_solr_index'

--- a/config/sync/views.view.oai_pmh_item_links.yml
+++ b/config/sync/views.view.oai_pmh_item_links.yml
@@ -1,0 +1,205 @@
+uuid: fef77d2f-ab24-441b-859a-1313d66cd293
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - user
+id: oai_pmh_item_links
+label: 'OAI-PMH Item Links'
+module: views
+description: ''
+tag: ''
+base_table: node_field_data
+base_field: nid
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'OAI-PMH Item Links'
+      fields:
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: nid
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: true
+            text: "{% set host =  url('<front>')|first|raw|replace({ 'https:': \"\", '/': \"\" }) %}\r\n<a href=\"/oai/request?identifier=oai%3A{{ host }}%3Anode-{{ nid }}&metadataPrefix=mods&verb=GetRecord\">Display MODS Record</a><br> \r\n<a href=\"/oai/request?identifier=oai%3A{{ host }}%3Anode-{{ nid }}&metadataPrefix=oai_dc&verb=GetRecord\">Display DC Record</a>"
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 5
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts: {  }
+      arguments:
+        nid:
+          id: nid
+          table: node_field_revision
+          field: nid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: nid
+          plugin_id: node_nid
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: node
+          default_argument_options: {  }
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+      style:
+        type: default
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  block_1:
+    id: block_1
+    display_title: Block
+    display_plugin: block
+    position: 1
+    display_options:
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }

--- a/config/sync/views.view.oai_pmh_item_links.yml
+++ b/config/sync/views.view.oai_pmh_item_links.yml
@@ -8,7 +8,7 @@ dependencies:
 id: oai_pmh_item_links
 label: 'OAI-PMH Item Links'
 module: views
-description: ''
+description: 'Provide links to MODS and DC serializations of a node.'
 tag: ''
 base_table: node_field_data
 base_field: nid
@@ -35,7 +35,7 @@ display:
           exclude: false
           alter:
             alter_text: true
-            text: "{% set host =  url('<front>')|first|raw|replace({ 'https:': \"\", '/': \"\" }) %}\r\n<a href=\"/oai/request?identifier=oai%3A{{ host }}%3Anode-{{ nid }}&metadataPrefix=mods&verb=GetRecord\">Display MODS Record</a><br> \r\n<a href=\"/oai/request?identifier=oai%3A{{ host }}%3Anode-{{ nid }}&metadataPrefix=oai_dc&verb=GetRecord\">Display DC Record</a>"
+            text: "{% set host =  url('<front>')|first|replace({ 'http:': '', 'https:': '', '/': ''})|split(':')|first %}\r\n<a href=\"/oai/request?identifier=oai%3A{{ host }}%3Anode-{{ nid }}&metadataPrefix=mods&verb=GetRecord\">{{ 'Display MODS Record'|t }}</a><br> \r\n<a href=\"/oai/request?identifier=oai%3A{{ host }}%3Anode-{{ nid }}&metadataPrefix=oai_dc&verb=GetRecord\">{{ 'Display DC Record'|t }}</a>"
             make_link: false
             path: ''
             absolute: false
@@ -193,7 +193,18 @@ display:
     display_plugin: block
     position: 1
     display_options:
-      display_extenders: {  }
+      display_extenders:
+        matomo:
+          enabled: false
+          keyword_gets: ''
+          keyword_behavior: first
+          keyword_concat_separator: ' '
+          category_behavior: none
+          category_gets: ''
+          category_concat_separator: ' '
+          category_fallback: ''
+          category_facets: {  }
+          category_facets_concat_separator: ', '
     cache_metadata:
       max-age: -1
       contexts:


### PR DESCRIPTION
This PR provides a MODS representation.  This is done by powering a twig powered OAI-PMH Record view powered by a Drupal view consisting of a given Repository Item metadata.

Composer Changes
* places a MODS template (mods.html.twig) via post-update-cmd

Config Changes
* rest_oai_pmh.settings - module config, sets up MODS
* views.view.oai_pmh_item_data - provides the metadata that powers the twig 
* search_api.index.default_solr_index - some additional fields such as the ID needed for the above view
* views.view.oai_pmh_item_links - sets up the block needed to show the link
* context.context.display_oai_pmh_item_links - places the block

Note that, All Repository Content OAI-PMH set did not include collection items.  I kept it that way.  Thus, these links don't show for collection items.  