### PR TITLE
Fix orphaned media view filter.

### DIFF
--- a/config/sync/views.view.media.yml
+++ b/config/sync/views.view.media.yml
@@ -1193,15 +1193,17 @@ display:
           hierarchy: false
           limit: true
           error_message: true
-        field_media_of_target_id:
-          id: field_media_of_target_id
-          table: media__field_media_of
-          field: field_media_of_target_id
-          relationship: none
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: field_media_of
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: nid
           plugin_id: numeric
-          operator: '='
+          operator: empty
           value:
             min: ''
             max: ''
@@ -1209,36 +1211,41 @@ display:
           group: 1
           exposed: true
           expose:
-            operator_id: field_media_of_target_id_op
-            label: 'Media of (field_media_of)'
-            description: null
+            operator_id: nid_op
+            label: 'Orphaned Media'
+            description: 'Media where the linked content does not exist'
             use_operator: false
-            operator: field_media_of_target_id_op
+            operator: nid_op
             operator_limit_selection: false
             operator_list: {  }
-            identifier: field_media_of_target_id
+            identifier: nid
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            min_placeholder: null
-            max_placeholder: null
-            placeholder: null
+              anonymous: '0'
+              content_editor: '0'
+              administrator: '0'
+              fedoraadmin: '0'
+            min_placeholder: ''
+            max_placeholder: ''
+            placeholder: ''
           is_grouped: true
           group_info:
             label: 'Orphaned Media'
-            description: 'Select missing media of to find orphaned media'
-            identifier: field_media_of_target_id
+            description: ''
+            identifier: nid
             optional: true
             widget: select
             multiple: false
             remember: false
             default_group: All
-            default_group_multiple: {  }
+            default_group_multiple:
+              All: 0
             group_items:
               1:
-                title: 'Missing Media Of'
+                title: 'Orphans - "Media of" is broken'
                 operator: empty
                 value:
                   min: ''

--- a/config/sync/views.view.media.yml
+++ b/config/sync/views.view.media.yml
@@ -1245,7 +1245,7 @@ display:
               All: 0
             group_items:
               1:
-                title: 'Orphans - "Media of" is broken'
+                title: 'Orphans: invalid/missing "Media of"'
                 operator: empty
                 value:
                   min: ''


### PR DESCRIPTION
This addresses #34 .

Previously, the "orphaned" filter found items where media_of was not set.
However, the most likely "orphan" case is when a node is deleted, and then media_of remains set but does not link to a real node.

This new filter for "Orphans" finds both:
* media with no media_of
* media where media_of is internally set to a non-existent node.

I've had a bit of trouble trying to get the nid of the deleted node to display transparently to the user. This is really difficult! Drupal does a lot of work to hide from you the fact that there is a referenced entity which does not exist.

Nonetheless, this change addresses "Finding orphans" which are being missed by the current view.