### PR TITLE
Don't show block title, and map linked agent to DC.

### DIFF
--- a/config/sync/context.context.display_oai_pmh_item_links.yml
+++ b/config/sync/context.context.display_oai_pmh_item_links.yml
@@ -38,7 +38,7 @@ reactions:
         id: 'views_block:oai_pmh_item_links-block_1'
         label: ''
         provider: views
-        label_display: visible
+        label_display: '0'
         region: content
         weight: '0'
         custom_id: views_block_oai_pmh_item_links_block_1

--- a/config/sync/rdf.mapping.node.islandora_object.yml
+++ b/config/sync/rdf.mapping.node.islandora_object.yml
@@ -152,6 +152,9 @@ fieldMappings:
   field_weight:
     properties:
       - 'co:index'
+  field_linked_agent:
+    properties:
+      - 'dcterms:contributor'
   title:
     properties:
       - 'dcterms:title'


### PR DESCRIPTION
Further to the OAI-PMH links being shown, 

* don't show the block title as "OAI-PMH Item Links" is very user-unfriendly.
* Map typed relation to a DC predicate in the RDF mapping, which means it will be found by OAI-PMH (which for DC only looks at the RDF mappings which are DC elements or DC terms.). This causes some duplication in the JSONLD mapping, as any linked agents (such as author and publisher) will be shown both as dc:contributor's and with their respective relators predicates.

Is this desirable?