### PR TITLE
OAI-PMH access for anonymous and authenticated users

### DIFF
--- a/config/sync/user.role.anonymous.yml
+++ b/config/sync/user.role.anonymous.yml
@@ -4,11 +4,13 @@ status: true
 dependencies:
   config:
     - filter.format.restricted_html
+    - rest.resource.oai_pmh
   module:
     - comment
     - contact
     - filter
     - media
+    - rest
     - system
 _core:
   default_config_hash: 6WavjUYXIegP9AAg2zXGx54MWIVoomC3SZhNiqe-Dyk
@@ -22,3 +24,4 @@ permissions:
   - 'access site-wide contact form'
   - 'use text format restricted_html'
   - 'view media'
+  - 'restful get oai_pmh'

--- a/config/sync/user.role.authenticated.yml
+++ b/config/sync/user.role.authenticated.yml
@@ -4,12 +4,14 @@ status: true
 dependencies:
   config:
     - filter.format.basic_html
+    - rest.resource.oai_pmh
   module:
     - comment
     - contact
     - filter
     - matomo
     - media
+    - rest
     - shortcut
     - system
 _core:
@@ -28,3 +30,4 @@ permissions:
   - 'skip comment approval'
   - 'use text format basic_html'
   - 'view media'
+  - 'restful get oai_pmh'


### PR DESCRIPTION
Changes the configuration for anonymous and authenticated users to be able to view MODS and DC records for repository objects.

Related issue: https://github.com/Islandora-Devops/islandora-starter-site/issues/79