### PR TITLE
Changing uri scheme from public to Fedora

### DIFF
--- a/config/sync/field.storage.media.field_media_image.yml
+++ b/config/sync/field.storage.media.field_media_image.yml
@@ -16,7 +16,7 @@ settings:
   target_type: file
   display_field: false
   display_default: false
-  uri_scheme: public
+  uri_scheme: fedora
   default_image:
     uuid: ''
     alt: ''


### PR DESCRIPTION
Changed configuration file for image storage to use Fedora instead of public.

Related issue: https://github.com/Islandora-Devops/islandora-starter-site/issues/78