### PR TITLE
remove scaffolding for settings.php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,18 +85,6 @@
         }
     },
     "extra": {
-        "drupal-scaffold": {
-            "locations": {
-                "web-root": "web/"
-            },
-            "file-mapping": {
-                "[web-root]/sites/default/settings.php": {
-                    "mode": "append",
-                    "default": "web/core/assets/scaffold/files/default.settings.php",
-                    "append": "assets/patches/default_settings.txt"
-                }
-            }
-        },
         "installer-paths": {
             "web/core": [
                 "type:drupal-core"


### PR DESCRIPTION
Fix for https://github.com/Islandora-Devops/isle-dc/issues/306

Scaffolding settings.php causes issues because settings.php is not writable. The patch is meant to set the sync directory in settings.php, but this is done already when the site is installed via Isle, so the patch is not necessary.

This fix solves the above issue for Isle, but may result in the config directory not being set in non-Isle installs like the playbook or a manual install.