### PR TITLE
Migration tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,12 +143,12 @@ Change the following Drupal configs to your values using any method (GUI,
     2. Setting the appropriate location as `key.key.islandora_rsa_key key_provider_settings.file_location`
 (using the methods listed in step 5 or at `/admin/config/system/keys/manage/islandora_rsa_key`)
 
-7. Run the migrations in the `islandora` migration group to populate the base
+7. Run the migrations tagged with `islandora` to populate some
 taxonomies, specifying the `--userid` targeting the user with the `fedoraadmin`
 role:
 
     ```bash
-    composer exec -- drush migrate:import --userid=1 islandora_tags,islandora_defaults_tags,islandora_fits_tags
+    composer exec -- drush migrate:import --userid=1 --tag=islandora
     ```
 
 

--- a/config/sync/migrate_plus.migration.islandora_defaults_tags.yml
+++ b/config/sync/migrate_plus.migration.islandora_defaults_tags.yml
@@ -10,6 +10,7 @@ field_plugin_method: null
 cck_plugin_method: null
 migration_tags:
   - islandora_defaults_tags
+  - islandora
 migration_group: islandora
 label: 'Tags migration for islandora_defaults feature'
 source:

--- a/config/sync/migrate_plus.migration.islandora_tags.yml
+++ b/config/sync/migrate_plus.migration.islandora_tags.yml
@@ -13,6 +13,7 @@ field_plugin_method: null
 cck_plugin_method: null
 migration_tags:
   - islandora_tags
+  - islandora
 migration_group: islandora
 label: 'Tags migration from CSV'
 source:


### PR DESCRIPTION
Ticket: https://github.com/Islandora/documentation/issues/2161
Related PR: https://github.com/Islandora/islandora_mirador/pull/21

This PR adds `islandora` as a tag for the two migrations that the Starter SIte contains. 

This allows us to call them all at once (along with islandora_fits_tags and islandora_mirador_tags if you have them installed). 

I also updated the README, which had contradictory instructions and example. It now instructs and shows migrating using the `--tag` option. 

