### PR TITLE
Remove patch now in core module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -127,11 +127,7 @@
                 "type:drupal-custom-theme"
             ]
         },
-        "patches": {
-            "drupal/rest_oai_pmh": {
-                "View render issue #3283661": "https://www.drupal.org/files/issues/2022-06-01/mods_view_render.patch"
-            }
-        }
+        "patches": {}
     },
     "scripts": {
         "post-root-package-install": ["Islandora\\StarterSite::rootPackageInstall"],

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "007adaeeb05fdac56f0fc96d7f08addb",
-
+    "content-hash": "8839a33a32ca3e404b39de66f51b6221",
     "packages": [
         {
             "name": "academicpuma/citeproc-php",
@@ -11836,5 +11835,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
The [issue the patch in this composer.json referenced](https://www.drupal.org/project/rest_oai_pmh/issues/3283661) is now in REST OAI-PMH.

## Steps to reproduce

```
$ git clone git@github.com:Islandora-Devops/isle-dc.git
$ cd isle-dc
$ make starter
...
...
Applying patches for drupal/rest_oai_pmh
    https://www.drupal.org/files/issues/2022-06-01/mods_view_render.patch (View render issue #3283661)
   Could not apply patch! Skipping. The error was: Cannot apply patch https://www.drupal.org/files/issues/2022-06-01/mods_view_render.patch
 ...
 ...
```