### PR TITLE
Newspaper Issues Calendar View

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
         "drupal/field_permissions": "^1",
         "drupal/field_report": "^2.1",
         "drupal/flysystem": "^2.0@alpha",
+        "drupal/fullcalendar_solr": "^1.0@beta",
         "drupal/hal": "^1.0||^2.0",
         "drupal/matomo": "^1.19",
         "drupal/pdf": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8839a33a32ca3e404b39de66f51b6221",
+    "content-hash": "acf3a46cf4a233063ad769d5f3790e4b",
     "packages": [
         {
             "name": "academicpuma/citeproc-php",
@@ -3141,6 +3141,63 @@
             "homepage": "https://www.drupal.org/project/flysystem",
             "support": {
                 "source": "https://git.drupalcode.org/project/flysystem"
+            }
+        },
+        {
+            "name": "drupal/fullcalendar_solr",
+            "version": "1.0.0-beta6",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/fullcalendar_solr.git",
+                "reference": "1.0.0-beta6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/fullcalendar_solr-1.0.0-beta6.zip",
+                "reference": "1.0.0-beta6",
+                "shasum": "005ada67228a2b0f243c0b0d7c364642a3e31718"
+            },
+            "require": {
+                "drupal/core": "^9 || ^10",
+                "drupal/search_api": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "1.0.0-beta6",
+                    "datestamp": "1686929783",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Project has not opted into security advisory coverage!"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "amym-li",
+                    "homepage": "https://www.drupal.org/user/3747823"
+                },
+                {
+                    "name": "kirsta",
+                    "homepage": "https://www.drupal.org/user/173761"
+                },
+                {
+                    "name": "Natkeeran",
+                    "homepage": "https://www.drupal.org/user/1016288"
+                },
+                {
+                    "name": "kylehuynh",
+                    "homepage": "https://www.drupal.org/user/3255474"
+                }
+            ],
+            "description": "Provides a View display style that renders a Year Calendar compatible with Search API",
+            "homepage": "https://www.drupal.org/project/fullcalendar_solr",
+            "support": {
+                "source": "https://git.drupalcode.org/project/fullcalendar_solr"
             }
         },
         {
@@ -11831,6 +11888,7 @@
         "drupal/bibcite": 10,
         "drupal/citation_select": 10,
         "drupal/flysystem": 15,
+        "drupal/fullcalendar_solr": 10,
         "drupal/rest_oai_pmh": 10,
         "drupal/term_merge": 10,
         "drupal/views_field_view": 10,

--- a/config/sync/block.block.calendarviewadvancedsearchfordayview.yml
+++ b/config/sync/block.block.calendarviewadvancedsearchfordayview.yml
@@ -1,4 +1,4 @@
-uuid: 7916c76d-15ae-454a-8a2b-02012ad8d4a2
+uuid: 3b330035-2acb-46a4-a6ed-2efbc90faaba
 langcode: en
 status: true
 dependencies:
@@ -8,21 +8,18 @@ dependencies:
     - islandora
   theme:
     - olivero
-id: solrsearchcontentadvancedsearchforblock
+id: calendarviewadvancedsearchfordayview
 theme: olivero
 region: sidebar
-weight: -23
+weight: -21
 provider: null
-plugin: 'advanced_search_block:solr_search_content__block_1'
+plugin: 'advanced_search_block:calendar_view__page_2'
 settings:
-  id: 'advanced_search_block:solr_search_content__block_1'
-  label: 'Search within Collection'
+  id: 'advanced_search_block:calendar_view__page_2'
+  label: 'Search Collection: Day'
   label_display: visible
   provider: advanced_search
-  fields:
-    - title_aggregated_fulltext
-    - abstract_description_fulltext
-    - linked_agent_name_fulltext
+  fields: {  }
   context_filter: field_member_of
 visibility:
   user_status:
@@ -36,14 +33,19 @@ visibility:
       own_page_true: '0'
       field_value: '0'
     user_fields: uid
+  view_inclusion:
+    id: view_inclusion
+    negate: false
+    view_inclusion:
+      view-calendar_view-page_2: view-calendar_view-page_2
+  context_all:
+    id: context_all
+    negate: null
+    values: ''
   context:
     id: context
     negate: null
     values: ''
-  context_all:
-    id: context_all
-    negate: null
-    values: collection
   media_source_mimetype:
     id: media_source_mimetype
     negate: false

--- a/config/sync/block.block.calendarviewadvancedsearchforyearview.yml
+++ b/config/sync/block.block.calendarviewadvancedsearchforyearview.yml
@@ -1,4 +1,4 @@
-uuid: 7916c76d-15ae-454a-8a2b-02012ad8d4a2
+uuid: e6da1c41-4573-4a91-aeb9-bcc070fe55cc
 langcode: en
 status: true
 dependencies:
@@ -8,21 +8,18 @@ dependencies:
     - islandora
   theme:
     - olivero
-id: solrsearchcontentadvancedsearchforblock
+id: calendarviewadvancedsearchforyearview
 theme: olivero
 region: sidebar
-weight: -23
+weight: -22
 provider: null
-plugin: 'advanced_search_block:solr_search_content__block_1'
+plugin: 'advanced_search_block:calendar_view__page_1'
 settings:
-  id: 'advanced_search_block:solr_search_content__block_1'
-  label: 'Search within Collection'
+  id: 'advanced_search_block:calendar_view__page_1'
+  label: 'Search Collection: Year'
   label_display: visible
   provider: advanced_search
-  fields:
-    - title_aggregated_fulltext
-    - abstract_description_fulltext
-    - linked_agent_name_fulltext
+  fields: {  }
   context_filter: field_member_of
 visibility:
   user_status:
@@ -36,14 +33,19 @@ visibility:
       own_page_true: '0'
       field_value: '0'
     user_fields: uid
+  view_inclusion:
+    id: view_inclusion
+    negate: false
+    view_inclusion:
+      view-calendar_view-page_1: view-calendar_view-page_1
+  context_all:
+    id: context_all
+    negate: null
+    values: ''
   context:
     id: context
     negate: null
     values: ''
-  context_all:
-    id: context_all
-    negate: null
-    values: collection
   media_source_mimetype:
     id: media_source_mimetype
     negate: false

--- a/config/sync/block.block.calendarviewsearchresultspagerfordayview.yml
+++ b/config/sync/block.block.calendarviewsearchresultspagerfordayview.yml
@@ -1,4 +1,4 @@
-uuid: 7916c76d-15ae-454a-8a2b-02012ad8d4a2
+uuid: 026bac1a-10e8-4c79-a6c3-21830c178b49
 langcode: en
 status: true
 dependencies:
@@ -8,22 +8,17 @@ dependencies:
     - islandora
   theme:
     - olivero
-id: solrsearchcontentadvancedsearchforblock
+id: calendarviewsearchresultspagerfordayview
 theme: olivero
-region: sidebar
+region: content
 weight: -23
 provider: null
-plugin: 'advanced_search_block:solr_search_content__block_1'
+plugin: 'advanced_search_result_pager:calendar_view__page_2'
 settings:
-  id: 'advanced_search_block:solr_search_content__block_1'
-  label: 'Search within Collection'
-  label_display: visible
+  id: 'advanced_search_result_pager:calendar_view__page_2'
+  label: 'Calendar View: Search Results Pager for Day View'
+  label_display: '0'
   provider: advanced_search
-  fields:
-    - title_aggregated_fulltext
-    - abstract_description_fulltext
-    - linked_agent_name_fulltext
-  context_filter: field_member_of
 visibility:
   user_status:
     id: user_status
@@ -36,14 +31,19 @@ visibility:
       own_page_true: '0'
       field_value: '0'
     user_fields: uid
+  view_inclusion:
+    id: view_inclusion
+    negate: false
+    view_inclusion:
+      view-calendar_view-page_2: view-calendar_view-page_2
+  context_all:
+    id: context_all
+    negate: null
+    values: ''
   context:
     id: context
     negate: null
     values: ''
-  context_all:
-    id: context_all
-    negate: null
-    values: collection
   media_source_mimetype:
     id: media_source_mimetype
     negate: false

--- a/config/sync/block.block.creatorsandcontributors.yml
+++ b/config/sync/block.block.creatorsandcontributors.yml
@@ -15,7 +15,7 @@ _core:
 id: creatorsandcontributors
 theme: olivero
 region: sidebar
-weight: -10
+weight: -14
 provider: null
 plugin: 'facet_block:creators_and_contributors'
 settings:

--- a/config/sync/block.block.creatorsandcontributors_swc.yml
+++ b/config/sync/block.block.creatorsandcontributors_swc.yml
@@ -13,7 +13,7 @@ dependencies:
 id: creatorsandcontributors_swc
 theme: olivero
 region: sidebar
-weight: -9
+weight: -13
 provider: null
 plugin: 'facet_block:creators_and_contributors_swc'
 settings:

--- a/config/sync/block.block.creatorsandcontributorscd.yml
+++ b/config/sync/block.block.creatorsandcontributorscd.yml
@@ -1,29 +1,28 @@
-uuid: 7916c76d-15ae-454a-8a2b-02012ad8d4a2
+uuid: d400852a-a661-449c-9342-21da6e86fe22
 langcode: en
 status: true
 dependencies:
+  config:
+    - facets.facet.creators_and_contributors_cd
   module:
-    - advanced_search
     - context
+    - facets
     - islandora
   theme:
     - olivero
-id: solrsearchcontentadvancedsearchforblock
+id: creatorsandcontributorscd
 theme: olivero
 region: sidebar
-weight: -23
+weight: -11
 provider: null
-plugin: 'advanced_search_block:solr_search_content__block_1'
+plugin: 'facet_block:creators_and_contributors_cd'
 settings:
-  id: 'advanced_search_block:solr_search_content__block_1'
-  label: 'Search within Collection'
+  id: 'facet_block:creators_and_contributors_cd'
+  label: 'Creators and Contributors'
   label_display: visible
-  provider: advanced_search
-  fields:
-    - title_aggregated_fulltext
-    - abstract_description_fulltext
-    - linked_agent_name_fulltext
-  context_filter: field_member_of
+  provider: facets
+  context_mapping: {  }
+  block_id: creatorsandcontributorscd
 visibility:
   user_status:
     id: user_status
@@ -36,14 +35,19 @@ visibility:
       own_page_true: '0'
       field_value: '0'
     user_fields: uid
+  view_inclusion:
+    id: view_inclusion
+    negate: false
+    view_inclusion:
+      view-calendar_view-page_2: view-calendar_view-page_2
+  context_all:
+    id: context_all
+    negate: null
+    values: ''
   context:
     id: context
     negate: null
     values: ''
-  context_all:
-    id: context_all
-    negate: null
-    values: collection
   media_source_mimetype:
     id: media_source_mimetype
     negate: false

--- a/config/sync/block.block.creatorsandcontributorscy.yml
+++ b/config/sync/block.block.creatorsandcontributorscy.yml
@@ -1,29 +1,28 @@
-uuid: 7916c76d-15ae-454a-8a2b-02012ad8d4a2
+uuid: 5e3fff58-f30b-4425-85b2-77a791333158
 langcode: en
 status: true
 dependencies:
+  config:
+    - facets.facet.creators_and_contributors_cy
   module:
-    - advanced_search
     - context
+    - facets
     - islandora
   theme:
     - olivero
-id: solrsearchcontentadvancedsearchforblock
+id: creatorsandcontributorscy
 theme: olivero
 region: sidebar
-weight: -23
+weight: -12
 provider: null
-plugin: 'advanced_search_block:solr_search_content__block_1'
+plugin: 'facet_block:creators_and_contributors_cy'
 settings:
-  id: 'advanced_search_block:solr_search_content__block_1'
-  label: 'Search within Collection'
+  id: 'facet_block:creators_and_contributors_cy'
+  label: 'Creators and Contributors'
   label_display: visible
-  provider: advanced_search
-  fields:
-    - title_aggregated_fulltext
-    - abstract_description_fulltext
-    - linked_agent_name_fulltext
-  context_filter: field_member_of
+  provider: facets
+  context_mapping: {  }
+  block_id: creatorsandcontributorscy
 visibility:
   user_status:
     id: user_status
@@ -36,14 +35,19 @@ visibility:
       own_page_true: '0'
       field_value: '0'
     user_fields: uid
+  view_inclusion:
+    id: view_inclusion
+    negate: false
+    view_inclusion:
+      view-calendar_view-page_1: view-calendar_view-page_1
+  context_all:
+    id: context_all
+    negate: null
+    values: ''
   context:
     id: context
     negate: null
     values: ''
-  context_all:
-    id: context_all
-    negate: null
-    values: collection
   media_source_mimetype:
     id: media_source_mimetype
     negate: false

--- a/config/sync/block.block.memberof.yml
+++ b/config/sync/block.block.memberof.yml
@@ -13,7 +13,7 @@ dependencies:
 id: memberof
 theme: olivero
 region: sidebar
-weight: -12
+weight: -16
 provider: null
 plugin: 'facet_block:member_of'
 settings:

--- a/config/sync/block.block.memberofswc.yml
+++ b/config/sync/block.block.memberofswc.yml
@@ -13,7 +13,7 @@ dependencies:
 id: memberofswc
 theme: olivero
 region: sidebar
-weight: -11
+weight: -15
 provider: null
 plugin: 'facet_block:member_of_swc'
 settings:

--- a/config/sync/block.block.olivero_content.yml
+++ b/config/sync/block.block.olivero_content.yml
@@ -11,7 +11,7 @@ _core:
 id: olivero_content
 theme: olivero
 region: content
-weight: -11
+weight: -22
 provider: null
 plugin: system_main_block
 settings:

--- a/config/sync/block.block.physicalform.yml
+++ b/config/sync/block.block.physicalform.yml
@@ -15,7 +15,7 @@ _core:
 id: physicalform
 theme: olivero
 region: sidebar
-weight: -8
+weight: -10
 provider: null
 plugin: 'facet_block:physical_form'
 settings:

--- a/config/sync/block.block.physicalformcd.yml
+++ b/config/sync/block.block.physicalformcd.yml
@@ -1,29 +1,28 @@
-uuid: 7916c76d-15ae-454a-8a2b-02012ad8d4a2
+uuid: 059ce317-63a1-445a-ad11-5c1e9e0c8985
 langcode: en
 status: true
 dependencies:
+  config:
+    - facets.facet.physical_form_cd
   module:
-    - advanced_search
     - context
+    - facets
     - islandora
   theme:
     - olivero
-id: solrsearchcontentadvancedsearchforblock
+id: physicalformcd
 theme: olivero
 region: sidebar
-weight: -23
+weight: -7
 provider: null
-plugin: 'advanced_search_block:solr_search_content__block_1'
+plugin: 'facet_block:physical_form_cd'
 settings:
-  id: 'advanced_search_block:solr_search_content__block_1'
-  label: 'Search within Collection'
+  id: 'facet_block:physical_form_cd'
+  label: 'Physical Form'
   label_display: visible
-  provider: advanced_search
-  fields:
-    - title_aggregated_fulltext
-    - abstract_description_fulltext
-    - linked_agent_name_fulltext
-  context_filter: field_member_of
+  provider: facets
+  context_mapping: {  }
+  block_id: physicalformcd
 visibility:
   user_status:
     id: user_status
@@ -36,14 +35,19 @@ visibility:
       own_page_true: '0'
       field_value: '0'
     user_fields: uid
+  view_inclusion:
+    id: view_inclusion
+    negate: false
+    view_inclusion:
+      view-calendar_view-page_2: view-calendar_view-page_2
+  context_all:
+    id: context_all
+    negate: null
+    values: ''
   context:
     id: context
     negate: null
     values: ''
-  context_all:
-    id: context_all
-    negate: null
-    values: collection
   media_source_mimetype:
     id: media_source_mimetype
     negate: false

--- a/config/sync/block.block.physicalformcy.yml
+++ b/config/sync/block.block.physicalformcy.yml
@@ -1,29 +1,28 @@
-uuid: 7916c76d-15ae-454a-8a2b-02012ad8d4a2
+uuid: f8f836e0-2171-499b-9313-2e3af602ba1f
 langcode: en
 status: true
 dependencies:
+  config:
+    - facets.facet.physical_form_cy
   module:
-    - advanced_search
     - context
+    - facets
     - islandora
   theme:
     - olivero
-id: solrsearchcontentadvancedsearchforblock
+id: physicalformcy
 theme: olivero
 region: sidebar
-weight: -23
+weight: -8
 provider: null
-plugin: 'advanced_search_block:solr_search_content__block_1'
+plugin: 'facet_block:physical_form_cy'
 settings:
-  id: 'advanced_search_block:solr_search_content__block_1'
-  label: 'Search within Collection'
+  id: 'facet_block:physical_form_cy'
+  label: 'Physical Form'
   label_display: visible
-  provider: advanced_search
-  fields:
-    - title_aggregated_fulltext
-    - abstract_description_fulltext
-    - linked_agent_name_fulltext
-  context_filter: field_member_of
+  provider: facets
+  context_mapping: {  }
+  block_id: physicalformcy
 visibility:
   user_status:
     id: user_status
@@ -36,14 +35,19 @@ visibility:
       own_page_true: '0'
       field_value: '0'
     user_fields: uid
+  view_inclusion:
+    id: view_inclusion
+    negate: false
+    view_inclusion:
+      view-calendar_view-page_1: view-calendar_view-page_1
+  context_all:
+    id: context_all
+    negate: null
+    values: ''
   context:
     id: context
     negate: null
     values: ''
-  context_all:
-    id: context_all
-    negate: null
-    values: collection
   media_source_mimetype:
     id: media_source_mimetype
     negate: false

--- a/config/sync/block.block.physicalformswc.yml
+++ b/config/sync/block.block.physicalformswc.yml
@@ -13,7 +13,7 @@ dependencies:
 id: physicalformswc
 theme: olivero
 region: sidebar
-weight: -7
+weight: -9
 provider: null
 plugin: 'facet_block:physical_form_swc'
 settings:

--- a/config/sync/block.block.resource_type_swc.yml
+++ b/config/sync/block.block.resource_type_swc.yml
@@ -13,7 +13,7 @@ dependencies:
 id: resource_type_swc
 theme: olivero
 region: sidebar
-weight: -13
+weight: -19
 provider: null
 plugin: 'facet_block:resource_type_swc'
 settings:

--- a/config/sync/block.block.resourcetype.yml
+++ b/config/sync/block.block.resourcetype.yml
@@ -13,7 +13,7 @@ dependencies:
 id: resourcetype
 theme: olivero
 region: sidebar
-weight: -14
+weight: -20
 provider: null
 plugin: 'facet_block:resource_type'
 settings:

--- a/config/sync/block.block.resourcetypecd.yml
+++ b/config/sync/block.block.resourcetypecd.yml
@@ -1,29 +1,28 @@
-uuid: 7916c76d-15ae-454a-8a2b-02012ad8d4a2
+uuid: 844f0b8b-73f9-4b3b-85ac-01bf1292c98b
 langcode: en
 status: true
 dependencies:
+  config:
+    - facets.facet.resource_type_cd
   module:
-    - advanced_search
     - context
+    - facets
     - islandora
   theme:
     - olivero
-id: solrsearchcontentadvancedsearchforblock
+id: resourcetypecd
 theme: olivero
 region: sidebar
-weight: -23
+weight: -17
 provider: null
-plugin: 'advanced_search_block:solr_search_content__block_1'
+plugin: 'facet_block:resource_type_cd'
 settings:
-  id: 'advanced_search_block:solr_search_content__block_1'
-  label: 'Search within Collection'
+  id: 'facet_block:resource_type_cd'
+  label: 'Resource Type'
   label_display: visible
-  provider: advanced_search
-  fields:
-    - title_aggregated_fulltext
-    - abstract_description_fulltext
-    - linked_agent_name_fulltext
-  context_filter: field_member_of
+  provider: facets
+  context_mapping: {  }
+  block_id: resourcetypecd
 visibility:
   user_status:
     id: user_status
@@ -36,14 +35,19 @@ visibility:
       own_page_true: '0'
       field_value: '0'
     user_fields: uid
+  view_inclusion:
+    id: view_inclusion
+    negate: false
+    view_inclusion:
+      view-calendar_view-page_2: view-calendar_view-page_2
+  context_all:
+    id: context_all
+    negate: null
+    values: ''
   context:
     id: context
     negate: null
     values: ''
-  context_all:
-    id: context_all
-    negate: null
-    values: collection
   media_source_mimetype:
     id: media_source_mimetype
     negate: false

--- a/config/sync/block.block.resourcetypecy.yml
+++ b/config/sync/block.block.resourcetypecy.yml
@@ -1,29 +1,28 @@
-uuid: 7916c76d-15ae-454a-8a2b-02012ad8d4a2
+uuid: ed0b9e07-6de8-430b-86b8-5c5407464e6d
 langcode: en
 status: true
 dependencies:
+  config:
+    - facets.facet.resource_type_cy
   module:
-    - advanced_search
     - context
+    - facets
     - islandora
   theme:
     - olivero
-id: solrsearchcontentadvancedsearchforblock
+id: resourcetypecy
 theme: olivero
 region: sidebar
-weight: -23
+weight: -18
 provider: null
-plugin: 'advanced_search_block:solr_search_content__block_1'
+plugin: 'facet_block:resource_type_cy'
 settings:
-  id: 'advanced_search_block:solr_search_content__block_1'
-  label: 'Search within Collection'
+  id: 'facet_block:resource_type_cy'
+  label: 'Resource Type'
   label_display: visible
-  provider: advanced_search
-  fields:
-    - title_aggregated_fulltext
-    - abstract_description_fulltext
-    - linked_agent_name_fulltext
-  context_filter: field_member_of
+  provider: facets
+  context_mapping: {  }
+  block_id: resourcetypecy
 visibility:
   user_status:
     id: user_status
@@ -36,14 +35,19 @@ visibility:
       own_page_true: '0'
       field_value: '0'
     user_fields: uid
+  view_inclusion:
+    id: view_inclusion
+    negate: false
+    view_inclusion:
+      view-calendar_view-page_1: view-calendar_view-page_1
+  context_all:
+    id: context_all
+    negate: null
+    values: ''
   context:
     id: context
     negate: null
     values: ''
-  context_all:
-    id: context_all
-    negate: null
-    values: collection
   media_source_mimetype:
     id: media_source_mimetype
     negate: false

--- a/config/sync/block.block.solrsearchcontentadvancedsearchforpage.yml
+++ b/config/sync/block.block.solrsearchcontentadvancedsearchforpage.yml
@@ -11,7 +11,7 @@ dependencies:
 id: solrsearchcontentadvancedsearchforpage
 theme: olivero
 region: sidebar
-weight: -16
+weight: -24
 provider: null
 plugin: 'advanced_search_block:solr_search_content__page_1'
 settings:

--- a/config/sync/block.block.solrsearchcontentsearchresultspagerforblock.yml
+++ b/config/sync/block.block.solrsearchcontentsearchresultspagerforblock.yml
@@ -11,7 +11,7 @@ dependencies:
 id: solrsearchcontentsearchresultspagerforblock
 theme: olivero
 region: content
-weight: -10
+weight: -21
 provider: null
 plugin: 'advanced_search_result_pager:solr_search_content__block_1'
 settings:

--- a/config/sync/block.block.solrsearchcontentsearchresultspagerforpage.yml
+++ b/config/sync/block.block.solrsearchcontentsearchresultspagerforpage.yml
@@ -11,7 +11,7 @@ dependencies:
 id: solrsearchcontentsearchresultspagerforpage
 theme: olivero
 region: content
-weight: -12
+weight: -24
 provider: null
 plugin: 'advanced_search_result_pager:solr_search_content__page_1'
 settings:

--- a/config/sync/block.block.subjectcd.yml
+++ b/config/sync/block.block.subjectcd.yml
@@ -1,29 +1,28 @@
-uuid: 7916c76d-15ae-454a-8a2b-02012ad8d4a2
+uuid: cd430961-418b-45be-844b-82ed417d306a
 langcode: en
 status: true
 dependencies:
+  config:
+    - facets.facet.subject_cd
   module:
-    - advanced_search
     - context
+    - facets
     - islandora
   theme:
     - olivero
-id: solrsearchcontentadvancedsearchforblock
+id: subjectcd
 theme: olivero
 region: sidebar
-weight: -23
+weight: -3
 provider: null
-plugin: 'advanced_search_block:solr_search_content__block_1'
+plugin: 'facet_block:subject_cd'
 settings:
-  id: 'advanced_search_block:solr_search_content__block_1'
-  label: 'Search within Collection'
+  id: 'facet_block:subject_cd'
+  label: Subject
   label_display: visible
-  provider: advanced_search
-  fields:
-    - title_aggregated_fulltext
-    - abstract_description_fulltext
-    - linked_agent_name_fulltext
-  context_filter: field_member_of
+  provider: facets
+  context_mapping: {  }
+  block_id: subjectcd
 visibility:
   user_status:
     id: user_status
@@ -36,14 +35,19 @@ visibility:
       own_page_true: '0'
       field_value: '0'
     user_fields: uid
+  view_inclusion:
+    id: view_inclusion
+    negate: false
+    view_inclusion:
+      view-calendar_view-page_2: view-calendar_view-page_2
+  context_all:
+    id: context_all
+    negate: null
+    values: ''
   context:
     id: context
     negate: null
     values: ''
-  context_all:
-    id: context_all
-    negate: null
-    values: collection
   media_source_mimetype:
     id: media_source_mimetype
     negate: false

--- a/config/sync/block.block.subjectcy.yml
+++ b/config/sync/block.block.subjectcy.yml
@@ -1,29 +1,28 @@
-uuid: 7916c76d-15ae-454a-8a2b-02012ad8d4a2
+uuid: 373254d6-d154-4123-bf6f-6182feb80e73
 langcode: en
 status: true
 dependencies:
+  config:
+    - facets.facet.subject_cy
   module:
-    - advanced_search
     - context
+    - facets
     - islandora
   theme:
     - olivero
-id: solrsearchcontentadvancedsearchforblock
+id: subjectcy
 theme: olivero
 region: sidebar
-weight: -23
+weight: -4
 provider: null
-plugin: 'advanced_search_block:solr_search_content__block_1'
+plugin: 'facet_block:subject_cy'
 settings:
-  id: 'advanced_search_block:solr_search_content__block_1'
-  label: 'Search within Collection'
+  id: 'facet_block:subject_cy'
+  label: Subject
   label_display: visible
-  provider: advanced_search
-  fields:
-    - title_aggregated_fulltext
-    - abstract_description_fulltext
-    - linked_agent_name_fulltext
-  context_filter: field_member_of
+  provider: facets
+  context_mapping: {  }
+  block_id: subjectcy
 visibility:
   user_status:
     id: user_status
@@ -36,14 +35,19 @@ visibility:
       own_page_true: '0'
       field_value: '0'
     user_fields: uid
+  view_inclusion:
+    id: view_inclusion
+    negate: false
+    view_inclusion:
+      view-calendar_view-page_1: view-calendar_view-page_1
+  context_all:
+    id: context_all
+    negate: null
+    values: ''
   context:
     id: context
     negate: null
     values: ''
-  context_all:
-    id: context_all
-    negate: null
-    values: collection
   media_source_mimetype:
     id: media_source_mimetype
     negate: false

--- a/config/sync/block.block.subjectname.yml
+++ b/config/sync/block.block.subjectname.yml
@@ -15,7 +15,7 @@ _core:
 id: subjectname
 theme: olivero
 region: sidebar
-weight: -4
+weight: -2
 provider: null
 plugin: 'facet_block:subject_name'
 settings:

--- a/config/sync/block.block.subjectnamescd.yml
+++ b/config/sync/block.block.subjectnamescd.yml
@@ -1,29 +1,28 @@
-uuid: 7916c76d-15ae-454a-8a2b-02012ad8d4a2
+uuid: 775e8e00-b9af-46a3-9349-845a5d9fd21c
 langcode: en
 status: true
 dependencies:
+  config:
+    - facets.facet.subject_names_cd
   module:
-    - advanced_search
     - context
+    - facets
     - islandora
   theme:
     - olivero
-id: solrsearchcontentadvancedsearchforblock
+id: subjectnamescd
 theme: olivero
 region: sidebar
-weight: -23
+weight: 1
 provider: null
-plugin: 'advanced_search_block:solr_search_content__block_1'
+plugin: 'facet_block:subject_names_cd'
 settings:
-  id: 'advanced_search_block:solr_search_content__block_1'
-  label: 'Search within Collection'
+  id: 'facet_block:subject_names_cd'
+  label: 'Subject (name)'
   label_display: visible
-  provider: advanced_search
-  fields:
-    - title_aggregated_fulltext
-    - abstract_description_fulltext
-    - linked_agent_name_fulltext
-  context_filter: field_member_of
+  provider: facets
+  context_mapping: {  }
+  block_id: subjectnamescd
 visibility:
   user_status:
     id: user_status
@@ -36,14 +35,19 @@ visibility:
       own_page_true: '0'
       field_value: '0'
     user_fields: uid
+  view_inclusion:
+    id: view_inclusion
+    negate: false
+    view_inclusion:
+      view-calendar_view-page_2: view-calendar_view-page_2
+  context_all:
+    id: context_all
+    negate: null
+    values: ''
   context:
     id: context
     negate: null
     values: ''
-  context_all:
-    id: context_all
-    negate: null
-    values: collection
   media_source_mimetype:
     id: media_source_mimetype
     negate: false

--- a/config/sync/block.block.subjectnamescy.yml
+++ b/config/sync/block.block.subjectnamescy.yml
@@ -1,29 +1,28 @@
-uuid: 7916c76d-15ae-454a-8a2b-02012ad8d4a2
+uuid: 9da6aaff-4b21-4beb-b7cd-1d9da8c9c8bc
 langcode: en
 status: true
 dependencies:
+  config:
+    - facets.facet.subject_names_cy
   module:
-    - advanced_search
     - context
+    - facets
     - islandora
   theme:
     - olivero
-id: solrsearchcontentadvancedsearchforblock
+id: subjectnamescy
 theme: olivero
 region: sidebar
-weight: -23
+weight: 0
 provider: null
-plugin: 'advanced_search_block:solr_search_content__block_1'
+plugin: 'facet_block:subject_names_cy'
 settings:
-  id: 'advanced_search_block:solr_search_content__block_1'
-  label: 'Search within Collection'
+  id: 'facet_block:subject_names_cy'
+  label: 'Subject (name)'
   label_display: visible
-  provider: advanced_search
-  fields:
-    - title_aggregated_fulltext
-    - abstract_description_fulltext
-    - linked_agent_name_fulltext
-  context_filter: field_member_of
+  provider: facets
+  context_mapping: {  }
+  block_id: subjectnamescy
 visibility:
   user_status:
     id: user_status
@@ -36,14 +35,19 @@ visibility:
       own_page_true: '0'
       field_value: '0'
     user_fields: uid
+  view_inclusion:
+    id: view_inclusion
+    negate: false
+    view_inclusion:
+      view-calendar_view-page_1: view-calendar_view-page_1
+  context_all:
+    id: context_all
+    negate: null
+    values: ''
   context:
     id: context
     negate: null
     values: ''
-  context_all:
-    id: context_all
-    negate: null
-    values: collection
   media_source_mimetype:
     id: media_source_mimetype
     negate: false

--- a/config/sync/block.block.subjectnamesswc.yml
+++ b/config/sync/block.block.subjectnamesswc.yml
@@ -13,7 +13,7 @@ dependencies:
 id: subjectnamesswc
 theme: olivero
 region: sidebar
-weight: -3
+weight: -1
 provider: null
 plugin: 'facet_block:subject_names_swc'
 settings:

--- a/config/sync/block.block.subjecttemporalcd.yml
+++ b/config/sync/block.block.subjecttemporalcd.yml
@@ -1,29 +1,28 @@
-uuid: 7916c76d-15ae-454a-8a2b-02012ad8d4a2
+uuid: 948975bb-0019-4e2c-9dd1-d926e5ffee3d
 langcode: en
 status: true
 dependencies:
+  config:
+    - facets.facet.subject_temporal_cd
   module:
-    - advanced_search
     - context
+    - facets
     - islandora
   theme:
     - olivero
-id: solrsearchcontentadvancedsearchforblock
+id: subjecttemporalcd
 theme: olivero
 region: sidebar
-weight: -23
+weight: 5
 provider: null
-plugin: 'advanced_search_block:solr_search_content__block_1'
+plugin: 'facet_block:subject_temporal_cd'
 settings:
-  id: 'advanced_search_block:solr_search_content__block_1'
-  label: 'Search within Collection'
+  id: 'facet_block:subject_temporal_cd'
+  label: 'Temporal Subject'
   label_display: visible
-  provider: advanced_search
-  fields:
-    - title_aggregated_fulltext
-    - abstract_description_fulltext
-    - linked_agent_name_fulltext
-  context_filter: field_member_of
+  provider: facets
+  context_mapping: {  }
+  block_id: subjecttemporalcd
 visibility:
   user_status:
     id: user_status
@@ -36,14 +35,19 @@ visibility:
       own_page_true: '0'
       field_value: '0'
     user_fields: uid
+  view_inclusion:
+    id: view_inclusion
+    negate: false
+    view_inclusion:
+      view-calendar_view-page_2: view-calendar_view-page_2
+  context_all:
+    id: context_all
+    negate: null
+    values: ''
   context:
     id: context
     negate: null
     values: ''
-  context_all:
-    id: context_all
-    negate: null
-    values: collection
   media_source_mimetype:
     id: media_source_mimetype
     negate: false

--- a/config/sync/block.block.subjecttemporalcy.yml
+++ b/config/sync/block.block.subjecttemporalcy.yml
@@ -1,29 +1,28 @@
-uuid: 7916c76d-15ae-454a-8a2b-02012ad8d4a2
+uuid: 0da954ca-1381-4906-808e-3381ae2aff5d
 langcode: en
 status: true
 dependencies:
+  config:
+    - facets.facet.subject_temporal_cy
   module:
-    - advanced_search
     - context
+    - facets
     - islandora
   theme:
     - olivero
-id: solrsearchcontentadvancedsearchforblock
+id: subjecttemporalcy
 theme: olivero
 region: sidebar
-weight: -23
+weight: 4
 provider: null
-plugin: 'advanced_search_block:solr_search_content__block_1'
+plugin: 'facet_block:subject_temporal_cy'
 settings:
-  id: 'advanced_search_block:solr_search_content__block_1'
-  label: 'Search within Collection'
+  id: 'facet_block:subject_temporal_cy'
+  label: 'Temporal Subject'
   label_display: visible
-  provider: advanced_search
-  fields:
-    - title_aggregated_fulltext
-    - abstract_description_fulltext
-    - linked_agent_name_fulltext
-  context_filter: field_member_of
+  provider: facets
+  context_mapping: {  }
+  block_id: subjecttemporalcy
 visibility:
   user_status:
     id: user_status
@@ -36,14 +35,19 @@ visibility:
       own_page_true: '0'
       field_value: '0'
     user_fields: uid
+  view_inclusion:
+    id: view_inclusion
+    negate: false
+    view_inclusion:
+      view-calendar_view-page_1: view-calendar_view-page_1
+  context_all:
+    id: context_all
+    negate: null
+    values: ''
   context:
     id: context
     negate: null
     values: ''
-  context_all:
-    id: context_all
-    negate: null
-    values: collection
   media_source_mimetype:
     id: media_source_mimetype
     negate: false

--- a/config/sync/block.block.subjecttemporalswc.yml
+++ b/config/sync/block.block.subjecttemporalswc.yml
@@ -13,7 +13,7 @@ dependencies:
 id: subjecttemporalswc
 theme: olivero
 region: sidebar
-weight: -1
+weight: 3
 provider: null
 plugin: 'facet_block:subject_temporal_swc'
 settings:

--- a/config/sync/block.block.temporalsubject.yml
+++ b/config/sync/block.block.temporalsubject.yml
@@ -15,7 +15,7 @@ _core:
 id: temporalsubject
 theme: olivero
 region: sidebar
-weight: -2
+weight: 2
 provider: null
 plugin: 'facet_block:temporal_subject'
 settings:

--- a/config/sync/block.block.views_block__solr_search_content_block_1.yml
+++ b/config/sync/block.block.views_block__solr_search_content_block_1.yml
@@ -13,7 +13,7 @@ dependencies:
 id: views_block__solr_search_content_block_1
 theme: olivero
 region: content
-weight: -9
+weight: -20
 provider: null
 plugin: 'views_block:solr_search_content-block_1'
 settings:

--- a/config/sync/block.block.year.yml
+++ b/config/sync/block.block.year.yml
@@ -13,7 +13,7 @@ dependencies:
 id: year
 theme: olivero
 region: sidebar
-weight: 0
+weight: 6
 provider: null
 plugin: 'facet_block:year'
 settings:

--- a/config/sync/block.block.yearswc.yml
+++ b/config/sync/block.block.yearswc.yml
@@ -13,7 +13,7 @@ dependencies:
 id: yearswc
 theme: olivero
 region: sidebar
-weight: 0
+weight: 7
 provider: null
 plugin: 'facet_block:year_swc'
 settings:

--- a/config/sync/context.context.newspaper.yml
+++ b/config/sync/context.context.newspaper.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - views.view.calendar_view
     - views.view.newspaper_issues_accordion_view
   module:
     - islandora
@@ -36,6 +37,23 @@ reactions:
         region: content
         weight: '0'
         custom_id: views_block_newspaper_issues_accordion_view_block_1
+        theme: olivero
+        css_class: ''
+        unique: 0
+        context_id: newspaper
+        context_mapping: {  }
+        views_label: ''
+        items_per_page: none
+        third_party_settings: {  }
+      d8db4214-d207-4c93-8f5b-25a1fd852f6e:
+        uuid: d8db4214-d207-4c93-8f5b-25a1fd852f6e
+        id: 'views_block:calendar_view-block_1'
+        label: ''
+        provider: views
+        label_display: '0'
+        region: content
+        weight: '0'
+        custom_id: views_block_calendar_view_block_1
         theme: olivero
         css_class: ''
         unique: 0

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -45,6 +45,7 @@ module:
   filehash: 0
   filter: 0
   flysystem: 0
+  fullcalendar_solr: 0
   geolocation: 0
   hal: 0
   help: 0

--- a/config/sync/facets.facet.creators_and_contributors_cd.yml
+++ b/config/sync/facets.facet.creators_and_contributors_cd.yml
@@ -1,0 +1,79 @@
+uuid: 66e79093-4bfb-4849-aa96-d7d9bd18411c
+langcode: en
+status: true
+dependencies:
+  config:
+    - search_api.index.default_solr_index
+    - views.view.calendar_view
+  module:
+    - search_api
+id: creators_and_contributors_cd
+name: 'Creators and Contributors CD'
+weight: -3
+min_count: 1
+missing: false
+missing_label: others
+url_alias: creators_and_contributors
+facet_source_id: 'search_api:views_page__calendar_view__page_2'
+field_identifier: field_linked_agent_name
+query_operator: or
+hard_limit: 0
+exclude: false
+use_hierarchy: false
+keep_hierarchy_parents_active: false
+hierarchy:
+  type: taxonomy
+  config: {  }
+expand_hierarchy: false
+enable_parent_when_child_gets_disabled: true
+widget:
+  type: links
+  config:
+    show_numbers: true
+    soft_limit: 10
+    show_reset_link: false
+    reset_text: 'Show all'
+    hide_reset_when_no_selection: false
+    soft_limit_settings:
+      show_less_label: 'Show less'
+      show_more_label: 'Show more'
+empty_behavior:
+  behavior: none
+only_visible_when_facet_source_is_visible: true
+show_only_one_result: false
+show_title: false
+processor_configs:
+  active_widget_order:
+    processor_id: active_widget_order
+    weights:
+      sort: 20
+    settings:
+      sort: DESC
+  count_widget_order:
+    processor_id: count_widget_order
+    weights:
+      sort: 30
+    settings:
+      sort: DESC
+  display_value_widget_order:
+    processor_id: display_value_widget_order
+    weights:
+      sort: 40
+    settings:
+      sort: ASC
+  hide_inactive_siblings_processor:
+    processor_id: hide_inactive_siblings_processor
+    weights:
+      build: 10
+    settings: {  }
+  hierarchy_processor:
+    processor_id: hierarchy_processor
+    weights:
+      build: 100
+    settings: {  }
+  url_processor_handler:
+    processor_id: url_processor_handler
+    weights:
+      pre_query: 50
+      build: 15
+    settings: {  }

--- a/config/sync/facets.facet.creators_and_contributors_cy.yml
+++ b/config/sync/facets.facet.creators_and_contributors_cy.yml
@@ -1,0 +1,79 @@
+uuid: 92f594ff-8f49-4cd0-963a-3a799da2ed8b
+langcode: en
+status: true
+dependencies:
+  config:
+    - search_api.index.default_solr_index
+    - views.view.calendar_view
+  module:
+    - search_api
+id: creators_and_contributors_cy
+name: 'Creators and Contributors CY'
+weight: -3
+min_count: 1
+missing: false
+missing_label: others
+url_alias: creators_and_contributors
+facet_source_id: 'search_api:views_page__calendar_view__page_1'
+field_identifier: field_linked_agent_name
+query_operator: or
+hard_limit: 0
+exclude: false
+use_hierarchy: false
+keep_hierarchy_parents_active: false
+hierarchy:
+  type: taxonomy
+  config: {  }
+expand_hierarchy: false
+enable_parent_when_child_gets_disabled: true
+widget:
+  type: links
+  config:
+    show_numbers: true
+    soft_limit: 10
+    show_reset_link: false
+    reset_text: 'Show all'
+    hide_reset_when_no_selection: false
+    soft_limit_settings:
+      show_less_label: 'Show less'
+      show_more_label: 'Show more'
+empty_behavior:
+  behavior: none
+only_visible_when_facet_source_is_visible: true
+show_only_one_result: false
+show_title: false
+processor_configs:
+  active_widget_order:
+    processor_id: active_widget_order
+    weights:
+      sort: 20
+    settings:
+      sort: DESC
+  count_widget_order:
+    processor_id: count_widget_order
+    weights:
+      sort: 30
+    settings:
+      sort: DESC
+  display_value_widget_order:
+    processor_id: display_value_widget_order
+    weights:
+      sort: 40
+    settings:
+      sort: ASC
+  hide_inactive_siblings_processor:
+    processor_id: hide_inactive_siblings_processor
+    weights:
+      build: 10
+    settings: {  }
+  hierarchy_processor:
+    processor_id: hierarchy_processor
+    weights:
+      build: 100
+    settings: {  }
+  url_processor_handler:
+    processor_id: url_processor_handler
+    weights:
+      pre_query: 50
+      build: 15
+    settings: {  }

--- a/config/sync/facets.facet.physical_form_cd.yml
+++ b/config/sync/facets.facet.physical_form_cd.yml
@@ -1,0 +1,79 @@
+uuid: 1161f051-7112-4d56-96f4-205a40be69b0
+langcode: en
+status: true
+dependencies:
+  config:
+    - search_api.index.default_solr_index
+    - views.view.calendar_view
+  module:
+    - search_api
+id: physical_form_cd
+name: 'Physical Form CD'
+weight: -2
+min_count: 1
+missing: false
+missing_label: others
+url_alias: physical_form
+facet_source_id: 'search_api:views_page__calendar_view__page_2'
+field_identifier: field_physical_form
+query_operator: or
+hard_limit: 0
+exclude: false
+use_hierarchy: false
+keep_hierarchy_parents_active: false
+hierarchy:
+  type: taxonomy
+  config: {  }
+expand_hierarchy: false
+enable_parent_when_child_gets_disabled: true
+widget:
+  type: links
+  config:
+    show_numbers: true
+    soft_limit: 10
+    show_reset_link: false
+    reset_text: 'Show all'
+    hide_reset_when_no_selection: false
+    soft_limit_settings:
+      show_less_label: 'Show less'
+      show_more_label: 'Show more'
+empty_behavior:
+  behavior: none
+only_visible_when_facet_source_is_visible: true
+show_only_one_result: false
+show_title: false
+processor_configs:
+  active_widget_order:
+    processor_id: active_widget_order
+    weights:
+      sort: 20
+    settings:
+      sort: DESC
+  count_widget_order:
+    processor_id: count_widget_order
+    weights:
+      sort: 30
+    settings:
+      sort: DESC
+  display_value_widget_order:
+    processor_id: display_value_widget_order
+    weights:
+      sort: 40
+    settings:
+      sort: ASC
+  hide_inactive_siblings_processor:
+    processor_id: hide_inactive_siblings_processor
+    weights:
+      build: 10
+    settings: {  }
+  hierarchy_processor:
+    processor_id: hierarchy_processor
+    weights:
+      build: 100
+    settings: {  }
+  url_processor_handler:
+    processor_id: url_processor_handler
+    weights:
+      pre_query: 50
+      build: 15
+    settings: {  }

--- a/config/sync/facets.facet.physical_form_cy.yml
+++ b/config/sync/facets.facet.physical_form_cy.yml
@@ -1,0 +1,79 @@
+uuid: 375a7bd3-ded3-4c69-abd9-05943f262aa0
+langcode: en
+status: true
+dependencies:
+  config:
+    - search_api.index.default_solr_index
+    - views.view.calendar_view
+  module:
+    - search_api
+id: physical_form_cy
+name: 'Physical Form CY'
+weight: -2
+min_count: 1
+missing: false
+missing_label: others
+url_alias: physical_form
+facet_source_id: 'search_api:views_page__calendar_view__page_1'
+field_identifier: field_physical_form
+query_operator: or
+hard_limit: 0
+exclude: false
+use_hierarchy: false
+keep_hierarchy_parents_active: false
+hierarchy:
+  type: taxonomy
+  config: {  }
+expand_hierarchy: false
+enable_parent_when_child_gets_disabled: true
+widget:
+  type: links
+  config:
+    show_numbers: true
+    soft_limit: 10
+    show_reset_link: false
+    reset_text: 'Show all'
+    hide_reset_when_no_selection: false
+    soft_limit_settings:
+      show_less_label: 'Show less'
+      show_more_label: 'Show more'
+empty_behavior:
+  behavior: none
+only_visible_when_facet_source_is_visible: true
+show_only_one_result: false
+show_title: false
+processor_configs:
+  active_widget_order:
+    processor_id: active_widget_order
+    weights:
+      sort: 20
+    settings:
+      sort: DESC
+  count_widget_order:
+    processor_id: count_widget_order
+    weights:
+      sort: 30
+    settings:
+      sort: DESC
+  display_value_widget_order:
+    processor_id: display_value_widget_order
+    weights:
+      sort: 40
+    settings:
+      sort: ASC
+  hide_inactive_siblings_processor:
+    processor_id: hide_inactive_siblings_processor
+    weights:
+      build: 10
+    settings: {  }
+  hierarchy_processor:
+    processor_id: hierarchy_processor
+    weights:
+      build: 100
+    settings: {  }
+  url_processor_handler:
+    processor_id: url_processor_handler
+    weights:
+      pre_query: 50
+      build: 15
+    settings: {  }

--- a/config/sync/facets.facet.resource_type_cd.yml
+++ b/config/sync/facets.facet.resource_type_cd.yml
@@ -1,0 +1,89 @@
+uuid: 17400aa4-a262-44af-bd47-6d552e3650e5
+langcode: en
+status: true
+dependencies:
+  config:
+    - search_api.index.default_solr_index
+    - views.view.calendar_view
+  module:
+    - search_api
+id: resource_type_cd
+name: 'Resource Type CD'
+weight: -5
+min_count: 1
+missing: false
+missing_label: others
+url_alias: resource_type
+facet_source_id: 'search_api:views_page__calendar_view__page_2'
+field_identifier: field_resource_type
+query_operator: or
+hard_limit: 0
+exclude: false
+use_hierarchy: true
+keep_hierarchy_parents_active: false
+hierarchy:
+  type: taxonomy
+  config: {  }
+expand_hierarchy: true
+enable_parent_when_child_gets_disabled: false
+widget:
+  type: links
+  config:
+    show_numbers: true
+    soft_limit: 0
+    show_reset_link: false
+    reset_text: 'Show all'
+    hide_reset_when_no_selection: false
+    soft_limit_settings:
+      show_less_label: 'Show less'
+      show_more_label: 'Show more'
+empty_behavior:
+  behavior: none
+only_visible_when_facet_source_is_visible: true
+show_only_one_result: false
+show_title: false
+processor_configs:
+  active_widget_order:
+    processor_id: active_widget_order
+    weights:
+      sort: 20
+    settings:
+      sort: DESC
+  count_widget_order:
+    processor_id: count_widget_order
+    weights:
+      sort: 30
+    settings:
+      sort: DESC
+  display_value_widget_order:
+    processor_id: display_value_widget_order
+    weights:
+      sort: 40
+    settings:
+      sort: ASC
+  hide_inactive_siblings_processor:
+    processor_id: hide_inactive_siblings_processor
+    weights:
+      build: 10
+    settings: {  }
+  hierarchy_processor:
+    processor_id: hierarchy_processor
+    weights:
+      build: 100
+    settings: {  }
+  list_item:
+    processor_id: list_item
+    weights:
+      build: 5
+    settings: {  }
+  translate_entity:
+    processor_id: translate_entity
+    weights:
+      build: 5
+    settings: {  }
+  url_processor_handler:
+    processor_id: url_processor_handler
+    weights:
+      pre_query: 50
+      build: 15
+    settings: {  }

--- a/config/sync/facets.facet.resource_type_cy.yml
+++ b/config/sync/facets.facet.resource_type_cy.yml
@@ -1,0 +1,89 @@
+uuid: 4fea75a4-031c-4ce6-8a9c-e4fcbc00edd1
+langcode: en
+status: true
+dependencies:
+  config:
+    - search_api.index.default_solr_index
+    - views.view.calendar_view
+  module:
+    - search_api
+id: resource_type_cy
+name: 'Resource Type CY'
+weight: -5
+min_count: 1
+missing: false
+missing_label: others
+url_alias: resource_type
+facet_source_id: 'search_api:views_page__calendar_view__page_1'
+field_identifier: field_resource_type
+query_operator: or
+hard_limit: 0
+exclude: false
+use_hierarchy: true
+keep_hierarchy_parents_active: false
+hierarchy:
+  type: taxonomy
+  config: {  }
+expand_hierarchy: true
+enable_parent_when_child_gets_disabled: false
+widget:
+  type: links
+  config:
+    show_numbers: true
+    soft_limit: 0
+    show_reset_link: false
+    reset_text: 'Show all'
+    hide_reset_when_no_selection: false
+    soft_limit_settings:
+      show_less_label: 'Show less'
+      show_more_label: 'Show more'
+empty_behavior:
+  behavior: none
+only_visible_when_facet_source_is_visible: true
+show_only_one_result: false
+show_title: false
+processor_configs:
+  active_widget_order:
+    processor_id: active_widget_order
+    weights:
+      sort: 20
+    settings:
+      sort: DESC
+  count_widget_order:
+    processor_id: count_widget_order
+    weights:
+      sort: 30
+    settings:
+      sort: DESC
+  display_value_widget_order:
+    processor_id: display_value_widget_order
+    weights:
+      sort: 40
+    settings:
+      sort: ASC
+  hide_inactive_siblings_processor:
+    processor_id: hide_inactive_siblings_processor
+    weights:
+      build: 10
+    settings: {  }
+  hierarchy_processor:
+    processor_id: hierarchy_processor
+    weights:
+      build: 100
+    settings: {  }
+  list_item:
+    processor_id: list_item
+    weights:
+      build: 5
+    settings: {  }
+  translate_entity:
+    processor_id: translate_entity
+    weights:
+      build: 5
+    settings: {  }
+  url_processor_handler:
+    processor_id: url_processor_handler
+    weights:
+      pre_query: 50
+      build: 15
+    settings: {  }

--- a/config/sync/facets.facet.subject_cd.yml
+++ b/config/sync/facets.facet.subject_cd.yml
@@ -1,0 +1,79 @@
+uuid: 72d696f2-eb21-42de-8dc5-4fe564292e56
+langcode: en
+status: true
+dependencies:
+  config:
+    - search_api.index.default_solr_index
+    - views.view.calendar_view
+  module:
+    - search_api
+id: subject_cd
+name: 'Subject CD'
+weight: -1
+min_count: 1
+missing: false
+missing_label: others
+url_alias: subject
+facet_source_id: 'search_api:views_page__calendar_view__page_2'
+field_identifier: subject_general_name
+query_operator: or
+hard_limit: 0
+exclude: false
+use_hierarchy: false
+keep_hierarchy_parents_active: false
+hierarchy:
+  type: taxonomy
+  config: {  }
+expand_hierarchy: false
+enable_parent_when_child_gets_disabled: true
+widget:
+  type: links
+  config:
+    show_numbers: true
+    soft_limit: 10
+    show_reset_link: false
+    reset_text: 'Show all'
+    hide_reset_when_no_selection: false
+    soft_limit_settings:
+      show_less_label: 'Show less'
+      show_more_label: 'Show more'
+empty_behavior:
+  behavior: none
+only_visible_when_facet_source_is_visible: true
+show_only_one_result: false
+show_title: false
+processor_configs:
+  active_widget_order:
+    processor_id: active_widget_order
+    weights:
+      sort: 20
+    settings:
+      sort: DESC
+  count_widget_order:
+    processor_id: count_widget_order
+    weights:
+      sort: 30
+    settings:
+      sort: DESC
+  display_value_widget_order:
+    processor_id: display_value_widget_order
+    weights:
+      sort: 40
+    settings:
+      sort: ASC
+  hide_inactive_siblings_processor:
+    processor_id: hide_inactive_siblings_processor
+    weights:
+      build: 10
+    settings: {  }
+  hierarchy_processor:
+    processor_id: hierarchy_processor
+    weights:
+      build: 100
+    settings: {  }
+  url_processor_handler:
+    processor_id: url_processor_handler
+    weights:
+      pre_query: 50
+      build: 15
+    settings: {  }

--- a/config/sync/facets.facet.subject_cy.yml
+++ b/config/sync/facets.facet.subject_cy.yml
@@ -1,0 +1,79 @@
+uuid: 15d684bb-fe03-4109-8a5b-10e0f885157e
+langcode: en
+status: true
+dependencies:
+  config:
+    - search_api.index.default_solr_index
+    - views.view.calendar_view
+  module:
+    - search_api
+id: subject_cy
+name: 'Subject CY'
+weight: -1
+min_count: 1
+missing: false
+missing_label: others
+url_alias: subject
+facet_source_id: 'search_api:views_page__calendar_view__page_1'
+field_identifier: subject_general_name
+query_operator: or
+hard_limit: 0
+exclude: false
+use_hierarchy: false
+keep_hierarchy_parents_active: false
+hierarchy:
+  type: taxonomy
+  config: {  }
+expand_hierarchy: false
+enable_parent_when_child_gets_disabled: true
+widget:
+  type: links
+  config:
+    show_numbers: true
+    soft_limit: 10
+    show_reset_link: false
+    reset_text: 'Show all'
+    hide_reset_when_no_selection: false
+    soft_limit_settings:
+      show_less_label: 'Show less'
+      show_more_label: 'Show more'
+empty_behavior:
+  behavior: none
+only_visible_when_facet_source_is_visible: true
+show_only_one_result: false
+show_title: false
+processor_configs:
+  active_widget_order:
+    processor_id: active_widget_order
+    weights:
+      sort: 20
+    settings:
+      sort: DESC
+  count_widget_order:
+    processor_id: count_widget_order
+    weights:
+      sort: 30
+    settings:
+      sort: DESC
+  display_value_widget_order:
+    processor_id: display_value_widget_order
+    weights:
+      sort: 40
+    settings:
+      sort: ASC
+  hide_inactive_siblings_processor:
+    processor_id: hide_inactive_siblings_processor
+    weights:
+      build: 10
+    settings: {  }
+  hierarchy_processor:
+    processor_id: hierarchy_processor
+    weights:
+      build: 100
+    settings: {  }
+  url_processor_handler:
+    processor_id: url_processor_handler
+    weights:
+      pre_query: 50
+      build: 15
+    settings: {  }

--- a/config/sync/facets.facet.subject_names_cd.yml
+++ b/config/sync/facets.facet.subject_names_cd.yml
@@ -1,0 +1,79 @@
+uuid: 363c21dd-ede8-4e8d-aa00-58afe1df3737
+langcode: en
+status: true
+dependencies:
+  config:
+    - search_api.index.default_solr_index
+    - views.view.calendar_view
+  module:
+    - search_api
+id: subject_names_cd
+name: 'Subject (Names) CD'
+weight: 0
+min_count: 1
+missing: false
+missing_label: others
+url_alias: subject_name
+facet_source_id: 'search_api:views_page__calendar_view__page_2'
+field_identifier: subject_names_name
+query_operator: or
+hard_limit: 0
+exclude: false
+use_hierarchy: false
+keep_hierarchy_parents_active: false
+hierarchy:
+  type: taxonomy
+  config: {  }
+expand_hierarchy: false
+enable_parent_when_child_gets_disabled: true
+widget:
+  type: links
+  config:
+    show_numbers: true
+    soft_limit: 10
+    show_reset_link: false
+    reset_text: 'Show all'
+    hide_reset_when_no_selection: false
+    soft_limit_settings:
+      show_less_label: 'Show less'
+      show_more_label: 'Show more'
+empty_behavior:
+  behavior: none
+only_visible_when_facet_source_is_visible: true
+show_only_one_result: false
+show_title: false
+processor_configs:
+  active_widget_order:
+    processor_id: active_widget_order
+    weights:
+      sort: 20
+    settings:
+      sort: DESC
+  count_widget_order:
+    processor_id: count_widget_order
+    weights:
+      sort: 30
+    settings:
+      sort: DESC
+  display_value_widget_order:
+    processor_id: display_value_widget_order
+    weights:
+      sort: 40
+    settings:
+      sort: ASC
+  hide_inactive_siblings_processor:
+    processor_id: hide_inactive_siblings_processor
+    weights:
+      build: 10
+    settings: {  }
+  hierarchy_processor:
+    processor_id: hierarchy_processor
+    weights:
+      build: 100
+    settings: {  }
+  url_processor_handler:
+    processor_id: url_processor_handler
+    weights:
+      pre_query: 50
+      build: 15
+    settings: {  }

--- a/config/sync/facets.facet.subject_names_cy.yml
+++ b/config/sync/facets.facet.subject_names_cy.yml
@@ -1,0 +1,79 @@
+uuid: 67568f75-a400-440f-ab38-2e8a017ffaa9
+langcode: en
+status: true
+dependencies:
+  config:
+    - search_api.index.default_solr_index
+    - views.view.calendar_view
+  module:
+    - search_api
+id: subject_names_cy
+name: 'Subject (Names) CY'
+weight: 0
+min_count: 1
+missing: false
+missing_label: others
+url_alias: subject_name
+facet_source_id: 'search_api:views_page__calendar_view__page_1'
+field_identifier: subject_names_name
+query_operator: or
+hard_limit: 0
+exclude: false
+use_hierarchy: false
+keep_hierarchy_parents_active: false
+hierarchy:
+  type: taxonomy
+  config: {  }
+expand_hierarchy: false
+enable_parent_when_child_gets_disabled: true
+widget:
+  type: links
+  config:
+    show_numbers: true
+    soft_limit: 10
+    show_reset_link: false
+    reset_text: 'Show all'
+    hide_reset_when_no_selection: false
+    soft_limit_settings:
+      show_less_label: 'Show less'
+      show_more_label: 'Show more'
+empty_behavior:
+  behavior: none
+only_visible_when_facet_source_is_visible: true
+show_only_one_result: false
+show_title: false
+processor_configs:
+  active_widget_order:
+    processor_id: active_widget_order
+    weights:
+      sort: 20
+    settings:
+      sort: DESC
+  count_widget_order:
+    processor_id: count_widget_order
+    weights:
+      sort: 30
+    settings:
+      sort: DESC
+  display_value_widget_order:
+    processor_id: display_value_widget_order
+    weights:
+      sort: 40
+    settings:
+      sort: ASC
+  hide_inactive_siblings_processor:
+    processor_id: hide_inactive_siblings_processor
+    weights:
+      build: 10
+    settings: {  }
+  hierarchy_processor:
+    processor_id: hierarchy_processor
+    weights:
+      build: 100
+    settings: {  }
+  url_processor_handler:
+    processor_id: url_processor_handler
+    weights:
+      pre_query: 50
+      build: 15
+    settings: {  }

--- a/config/sync/facets.facet.subject_temporal_cd.yml
+++ b/config/sync/facets.facet.subject_temporal_cd.yml
@@ -1,0 +1,79 @@
+uuid: e07666dd-d17b-433c-9065-ae82f2aec22d
+langcode: en
+status: true
+dependencies:
+  config:
+    - search_api.index.default_solr_index
+    - views.view.calendar_view
+  module:
+    - search_api
+id: subject_temporal_cd
+name: 'Subject (Temporal) CD'
+weight: 1
+min_count: 1
+missing: false
+missing_label: others
+url_alias: temporal_subject
+facet_source_id: 'search_api:views_page__calendar_view__page_2'
+field_identifier: subject_temporal_name
+query_operator: or
+hard_limit: 0
+exclude: false
+use_hierarchy: false
+keep_hierarchy_parents_active: false
+hierarchy:
+  type: taxonomy
+  config: {  }
+expand_hierarchy: false
+enable_parent_when_child_gets_disabled: true
+widget:
+  type: links
+  config:
+    show_numbers: true
+    soft_limit: 10
+    show_reset_link: false
+    reset_text: 'Show all'
+    hide_reset_when_no_selection: false
+    soft_limit_settings:
+      show_less_label: 'Show less'
+      show_more_label: 'Show more'
+empty_behavior:
+  behavior: none
+only_visible_when_facet_source_is_visible: true
+show_only_one_result: false
+show_title: false
+processor_configs:
+  active_widget_order:
+    processor_id: active_widget_order
+    weights:
+      sort: 20
+    settings:
+      sort: DESC
+  count_widget_order:
+    processor_id: count_widget_order
+    weights:
+      sort: 30
+    settings:
+      sort: DESC
+  display_value_widget_order:
+    processor_id: display_value_widget_order
+    weights:
+      sort: 40
+    settings:
+      sort: ASC
+  hide_inactive_siblings_processor:
+    processor_id: hide_inactive_siblings_processor
+    weights:
+      build: 10
+    settings: {  }
+  hierarchy_processor:
+    processor_id: hierarchy_processor
+    weights:
+      build: 100
+    settings: {  }
+  url_processor_handler:
+    processor_id: url_processor_handler
+    weights:
+      pre_query: 50
+      build: 15
+    settings: {  }

--- a/config/sync/facets.facet.subject_temporal_cy.yml
+++ b/config/sync/facets.facet.subject_temporal_cy.yml
@@ -1,0 +1,79 @@
+uuid: 15838253-2807-41ab-9784-ffac6228c56a
+langcode: en
+status: true
+dependencies:
+  config:
+    - search_api.index.default_solr_index
+    - views.view.calendar_view
+  module:
+    - search_api
+id: subject_temporal_cy
+name: 'Subject (Temporal) CY'
+weight: 1
+min_count: 1
+missing: false
+missing_label: others
+url_alias: temporal_subject
+facet_source_id: 'search_api:views_page__calendar_view__page_1'
+field_identifier: subject_temporal_name
+query_operator: or
+hard_limit: 0
+exclude: false
+use_hierarchy: false
+keep_hierarchy_parents_active: false
+hierarchy:
+  type: taxonomy
+  config: {  }
+expand_hierarchy: false
+enable_parent_when_child_gets_disabled: true
+widget:
+  type: links
+  config:
+    show_numbers: true
+    soft_limit: 10
+    show_reset_link: false
+    reset_text: 'Show all'
+    hide_reset_when_no_selection: false
+    soft_limit_settings:
+      show_less_label: 'Show less'
+      show_more_label: 'Show more'
+empty_behavior:
+  behavior: none
+only_visible_when_facet_source_is_visible: true
+show_only_one_result: false
+show_title: false
+processor_configs:
+  active_widget_order:
+    processor_id: active_widget_order
+    weights:
+      sort: 20
+    settings:
+      sort: DESC
+  count_widget_order:
+    processor_id: count_widget_order
+    weights:
+      sort: 30
+    settings:
+      sort: DESC
+  display_value_widget_order:
+    processor_id: display_value_widget_order
+    weights:
+      sort: 40
+    settings:
+      sort: ASC
+  hide_inactive_siblings_processor:
+    processor_id: hide_inactive_siblings_processor
+    weights:
+      build: 10
+    settings: {  }
+  hierarchy_processor:
+    processor_id: hierarchy_processor
+    weights:
+      build: 100
+    settings: {  }
+  url_processor_handler:
+    processor_id: url_processor_handler
+    weights:
+      pre_query: 50
+      build: 15
+    settings: {  }

--- a/config/sync/facets.facet_source.search_api__views_page__calendar_view__page_1.yml
+++ b/config/sync/facets.facet_source.search_api__views_page__calendar_view__page_1.yml
@@ -1,0 +1,9 @@
+uuid: 11f94960-c57c-4a31-9ef0-d11aea01fcf3
+langcode: en
+status: true
+dependencies: {  }
+id: search_api__views_page__calendar_view__page_1
+name: 'search_api:views_page__calendar_view__page_1'
+filter_key: null
+url_processor: query_string
+breadcrumb: {  }

--- a/config/sync/facets.facet_source.search_api__views_page__calendar_view__page_2.yml
+++ b/config/sync/facets.facet_source.search_api__views_page__calendar_view__page_2.yml
@@ -1,0 +1,9 @@
+uuid: 355e047c-5451-4c65-9606-10c7fe032e1e
+langcode: en
+status: true
+dependencies: {  }
+id: search_api__views_page__calendar_view__page_2
+name: 'search_api:views_page__calendar_view__page_2'
+filter_key: null
+url_processor: query_string
+breadcrumb: {  }

--- a/config/sync/views.view.calendar_view.yml
+++ b/config/sync/views.view.calendar_view.yml
@@ -1,0 +1,1707 @@
+uuid: f481c88d-5bcf-42b8-9ade-0a8a4accee62
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_description
+    - field.storage.node.field_edtf_date_created
+    - search_api.index.default_solr_index
+  module:
+    - controlled_access_terms
+    - fullcalendar_solr
+    - search_api
+id: calendar_view
+label: 'Calendar View'
+module: views
+description: ''
+tag: ''
+base_table: search_api_index_default_solr_index
+base_field: search_api_id
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'Calendar Block'
+      fields:
+        field_edtf_date_created:
+          id: field_edtf_date_created
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_edtf_date_created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: search_api_field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: edtf_default
+          settings:
+            date_separator: dash
+            date_order: big_endian
+            month_format: mm
+            day_format: dd
+            year_format: 'y'
+            relationship: none
+            field_rendering: 1
+            fieldsets:
+              - more
+              - admin_label
+            custom_label: 0
+            label: ''
+            element_label_colon: 1
+            exclude: 0
+            element_type_enable: 0
+            element_type: ''
+            element_class_enable: 0
+            element_class: ''
+            element_label_type_enable: 0
+            element_label_type: ''
+            element_label_class_enable: 0
+            element_label_class: ''
+            element_wrapper_type_enable: 0
+            element_wrapper_type: ''
+            element_wrapper_class_enable: 0
+            element_wrapper_class: ''
+            element_default_classes: 1
+            alter:
+              alter_text: 0
+              text: ''
+              make_link: 0
+              path: ''
+              absolute: 0
+              replace_spaces: 0
+              external: 0
+              path_case: none
+              link_class: ''
+              alt: ''
+              rel: ''
+              prefix: ''
+              suffix: ''
+              target: ''
+              trim: 0
+              max_length: '0'
+              word_boundary: 1
+              ellipsis: 1
+              more_link: 0
+              more_link_text: ''
+              more_link_path: ''
+              html: 0
+              strip_tags: 0
+              preserve_tags: ''
+              trim_whitespace: 0
+              nl2br: 0
+            empty: ''
+            empty_zero: 0
+            hide_empty: 0
+            hide_alter_empty: 1
+            group_rows: 1
+            multi_type: separator
+            separator: ', '
+            delta_limit: '0'
+            delta_offset: '0'
+            delta_reversed: 0
+            delta_first_last: 0
+            click_sort_column: value
+            type: edtf_default
+            field_api_classes: 0
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+        member_of_title:
+          id: member_of_title
+          table: search_api_index_default_solr_index
+          field: member_of_title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_field
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+      pager:
+        type: mini
+        options:
+          offset: 0
+          items_per_page: 15
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: none
+        options: {  }
+      cache:
+        type: none
+        options: {  }
+      empty: {  }
+      sorts: {  }
+      arguments:
+        field_member_of:
+          id: field_member_of
+          table: search_api_index_default_solr_index
+          field: field_member_of
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: raw
+          default_argument_options:
+            index: 1
+            use_alias: false
+          default_argument_skip_url: false
+          summary_options: {  }
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+        edtf_year:
+          id: edtf_year
+          table: search_api_index_default_solr_index
+          field: edtf_year
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: raw
+          default_argument_options:
+            index: 4
+            use_alias: false
+          default_argument_skip_url: false
+          summary_options: {  }
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+      filters:
+        field_edtf_date_created:
+          id: field_edtf_date_created
+          table: search_api_index_default_solr_index
+          field: field_edtf_date_created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_string
+          operator: 'not empty'
+          value:
+            min: ''
+            max: ''
+            value: ''
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            min_placeholder: ''
+            max_placeholder: ''
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        type:
+          id: type
+          table: search_api_index_default_solr_index
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_options
+          operator: or
+          value:
+            islandora_object: islandora_object
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+      row:
+        type: fields
+      query:
+        type: search_api_query
+        options:
+          bypass_access: false
+          skip_access: false
+          preserve_facet_query_args: false
+          query_tags: {  }
+      relationships: {  }
+      use_ajax: true
+      header:
+        result:
+          id: result
+          table: views
+          field: result
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: result
+          empty: false
+          content: '<div id="ajax-page-summary" class="pager__summary">Displaying @start - @end of @total</div>'
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+      tags:
+        - 'config:field.storage.node.field_edtf_date_created'
+        - 'config:search_api.index.default_solr_index'
+        - 'search_api_list:default_solr_index'
+  block_1:
+    id: block_1
+    display_title: 'Calendar Link'
+    display_plugin: block
+    position: 3
+    display_options:
+      fields:
+        edtf_year:
+          id: edtf_year
+          table: search_api_index_default_solr_index
+          field: edtf_year
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_numeric
+          label: ''
+          exclude: false
+          alter:
+            alter_text: true
+            text: 'Calendar View'
+            make_link: true
+            path: '/node/{{ arguments.field_member_of }}/year/{{ edtf_year }}'
+            absolute: true
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: 'Browse: '
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: true
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ''
+          format_plural: false
+          format_plural_string: !!binary Aw==
+          prefix: ''
+          suffix: ''
+          link_to_item: false
+          use_highlighting: false
+          multi_type: separator
+          multi_separator: ', '
+          format_plural_values: {  }
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 1
+      sorts:
+        edtf_year:
+          id: edtf_year
+          table: search_api_index_default_solr_index
+          field: edtf_year
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+      arguments:
+        field_member_of:
+          id: field_member_of
+          table: search_api_index_default_solr_index
+          field: field_member_of
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: raw
+          default_argument_options:
+            index: 1
+            use_alias: false
+          default_argument_skip_url: false
+          summary_options: {  }
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+      filters:
+        edtf_year:
+          id: edtf_year
+          table: search_api_index_default_solr_index
+          field: edtf_year
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_numeric
+          operator: 'not empty'
+          value:
+            min: ''
+            max: ''
+            value: ''
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            min_placeholder: ''
+            max_placeholder: ''
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        type:
+          id: type
+          table: search_api_index_default_solr_index
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_options
+          operator: or
+          value:
+            islandora_object: islandora_object
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      defaults:
+        use_ajax: false
+        pager: false
+        style: true
+        row: true
+        fields: false
+        sorts: false
+        arguments: false
+        filters: false
+        filter_groups: false
+        header: false
+      use_ajax: false
+      display_description: ''
+      header: {  }
+      display_extenders:
+        matomo:
+          enabled: false
+          keyword_gets: ''
+          keyword_behavior: first
+          keyword_concat_separator: ' '
+          category_behavior: none
+          category_gets: ''
+          category_concat_separator: ' '
+          category_fallback: ''
+          category_facets: {  }
+          category_facets_concat_separator: ', '
+      block_description: 'Calendar Link'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url
+        - 'user.node_grants:view'
+      tags:
+        - 'config:search_api.index.default_solr_index'
+        - 'search_api_list:default_solr_index'
+  page_1:
+    id: page_1
+    display_title: 'Year View'
+    display_plugin: page
+    position: 1
+    display_options:
+      enabled: true
+      title: '{{ member_of_title }}'
+      fields:
+        member_of_title:
+          id: member_of_title
+          table: search_api_index_default_solr_index
+          field: member_of_title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_field
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+        field_edtf_date_created:
+          id: field_edtf_date_created
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_edtf_date_created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: search_api_field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: edtf_default
+          settings:
+            date_separator: dash
+            date_order: big_endian
+            month_format: mm
+            day_format: dd
+            year_format: 'y'
+            relationship: none
+            field_rendering: 1
+            fieldsets:
+              - more
+              - admin_label
+            custom_label: 0
+            label: ''
+            element_label_colon: 1
+            exclude: 0
+            element_type_enable: 0
+            element_type: ''
+            element_class_enable: 0
+            element_class: ''
+            element_label_type_enable: 0
+            element_label_type: ''
+            element_label_class_enable: 0
+            element_label_class: ''
+            element_wrapper_type_enable: 0
+            element_wrapper_type: ''
+            element_wrapper_class_enable: 0
+            element_wrapper_class: ''
+            element_default_classes: 1
+            alter:
+              alter_text: 0
+              text: ''
+              make_link: 0
+              path: ''
+              absolute: 0
+              replace_spaces: 0
+              external: 0
+              path_case: none
+              link_class: ''
+              alt: ''
+              rel: ''
+              prefix: ''
+              suffix: ''
+              target: ''
+              trim: 0
+              max_length: '0'
+              word_boundary: 1
+              ellipsis: 1
+              more_link: 0
+              more_link_text: ''
+              more_link_path: ''
+              html: 0
+              strip_tags: 0
+              preserve_tags: ''
+              trim_whitespace: 0
+              nl2br: 0
+            empty: ''
+            empty_zero: 0
+            hide_empty: 0
+            hide_alter_empty: 1
+            group_rows: 1
+            multi_type: separator
+            separator: ', '
+            delta_limit: '0'
+            delta_offset: '0'
+            delta_reversed: 0
+            delta_first_last: 0
+            click_sort_column: value
+            type: edtf_default
+            field_api_classes: 0
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 365
+      arguments:
+        field_member_of:
+          id: field_member_of
+          table: search_api_index_default_solr_index
+          field: field_member_of
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: raw
+          default_argument_options:
+            index: 1
+            use_alias: false
+          default_argument_skip_url: false
+          summary_options: {  }
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+        edtf_year:
+          id: edtf_year
+          table: search_api_index_default_solr_index
+          field: edtf_year
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: raw
+          default_argument_options:
+            index: 3
+            use_alias: false
+          default_argument_skip_url: false
+          summary_options: {  }
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+      style:
+        type: fullcalendar_solr
+        options:
+          date_field: field_edtf_date_created
+          year_field: edtf_year
+          heading_text: 'All issues for <year>'
+          no_results: true
+          fullcalendar_options:
+            multiMonthMinWidth: 180
+            multiMonthMaxColumns: 4
+            navLinks: true
+            eventBackgroundColor: '#1c90d9'
+          classes: ''
+          direct_to_item: 0
+          item_url_field: search_api_url
+      row:
+        type: fields
+        options: {  }
+      defaults:
+        title: false
+        pager: false
+        style: false
+        row: false
+        fields: false
+        arguments: false
+        header: false
+      display_description: ''
+      header:
+        result:
+          id: result
+          table: views
+          field: result
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: result
+          empty: false
+          content: 'Displaying @start - @end of @total'
+      display_extenders:
+        matomo:
+          enabled: false
+          keyword_gets: ''
+          keyword_behavior: first
+          keyword_concat_separator: ' '
+          category_behavior: none
+          category_gets: ''
+          category_concat_separator: ' '
+          category_fallback: ''
+          category_facets: {  }
+          category_facets_concat_separator: ', '
+      path: node/%node/year
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - 'user.node_grants:view'
+      tags:
+        - 'config:field.storage.node.field_edtf_date_created'
+        - 'config:search_api.index.default_solr_index'
+        - 'search_api_list:default_solr_index'
+  page_2:
+    id: page_2
+    display_title: 'Day View'
+    display_plugin: page
+    position: 2
+    display_options:
+      title: '{{ member_of_title }}:  {{ arguments.field_edtf_date_created }}'
+      fields:
+        nid:
+          id: nid
+          table: search_api_index_default_solr_index
+          field: nid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_field
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: false
+          fallback_handler: search_api_numeric
+          fallback_options:
+            set_precision: false
+            precision: 0
+            decimal: .
+            separator: ''
+            format_plural: false
+            format_plural_string: !!binary MQNAY291bnQ=
+            prefix: ''
+            suffix: ''
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+            format_plural_values:
+              - '1'
+              - '@count'
+        member_of_title:
+          id: member_of_title
+          table: search_api_index_default_solr_index
+          field: member_of_title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_field
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+        title:
+          id: title
+          table: search_api_index_default_solr_index
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: h3
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: false
+          fallback_handler: search_api
+          fallback_options:
+            link_to_item: true
+            use_highlighting: true
+            multi_type: separator
+            multi_separator: ', '
+        field_resource_type:
+          id: field_resource_type
+          table: search_api_index_default_solr_index
+          field: field_resource_type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_field
+          label: Type
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: field__item
+          element_label_type: ''
+          element_label_class: field__label
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: true
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: false
+          fallback_handler: search_api
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+        field_linked_agent_name:
+          id: field_linked_agent_name
+          table: search_api_index_default_solr_index
+          field: field_linked_agent_name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_field
+          label: Names
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: field__item
+          element_label_type: ''
+          element_label_class: field__label
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: true
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: false
+          fallback_handler: search_api
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+        field_description:
+          id: field_description
+          table: search_api_index_default_solr_index
+          field: field_description
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_field
+          label: Description
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 400
+            word_boundary: true
+            ellipsis: true
+            more_link: true
+            more_link_text: more
+            more_link_path: 'node/{{ nid }}'
+            strip_tags: false
+            trim: true
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: field__item
+          element_label_type: ''
+          element_label_class: field__label
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: true
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: basic_string
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+        processed:
+          id: processed
+          table: search_api_index_default_solr_index
+          field: processed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api
+          label: Abstract
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: true
+            max_length: 400
+            word_boundary: true
+            ellipsis: true
+            more_link: true
+            more_link_text: more
+            more_link_path: 'node/{{ nid }}'
+            strip_tags: false
+            trim: true
+            preserve_tags: ''
+            html: true
+          element_type: ''
+          element_class: field__item
+          element_label_type: ''
+          element_label_class: field__label
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: true
+          empty_zero: false
+          hide_alter_empty: true
+          link_to_item: false
+          use_highlighting: false
+          multi_type: separator
+          multi_separator: ', '
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: true
+          content:
+            value: '<strong>No results found </strong>'
+            format: basic_html
+          tokenize: false
+      sorts:
+        search_api_relevance:
+          id: search_api_relevance
+          table: search_api_index_default_solr_index
+          field: search_api_relevance
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api
+          order: DESC
+          expose:
+            label: Relevance
+            field_identifier: search_api_relevance
+          exposed: true
+        title:
+          id: title
+          table: search_api_index_default_solr_index
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api
+          order: ASC
+          expose:
+            label: Title
+            field_identifier: title
+          exposed: true
+      arguments:
+        field_member_of:
+          id: field_member_of
+          table: search_api_index_default_solr_index
+          field: field_member_of
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: raw
+          default_argument_options:
+            index: 1
+            use_alias: false
+          default_argument_skip_url: false
+          summary_options: {  }
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+        field_edtf_date_created:
+          id: field_edtf_date_created
+          table: search_api_index_default_solr_index
+          field: field_edtf_date_created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: raw
+          default_argument_options:
+            index: 3
+            use_alias: false
+          default_argument_skip_url: false
+          summary_options: {  }
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+      defaults:
+        empty: false
+        title: false
+        style: true
+        row: true
+        fields: false
+        sorts: false
+        arguments: false
+        header: false
+      display_description: ''
+      header:
+        result:
+          id: result
+          table: views
+          field: result
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: result
+          empty: false
+          content: '<div id="ajax-page-summary" class="pager__summary">Displaying @start - @end of @total</div>'
+      display_extenders:
+        matomo:
+          enabled: false
+          keyword_gets: ''
+          keyword_behavior: first
+          keyword_concat_separator: ' '
+          category_behavior: none
+          category_gets: ''
+          category_concat_separator: ' '
+          category_fallback: ''
+          category_facets: {  }
+          category_facets_concat_separator: ', '
+      path: node/%node/day
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'url.query_args:sort_by'
+        - 'url.query_args:sort_order'
+        - 'user.node_grants:view'
+      tags:
+        - 'config:field.storage.node.field_description'
+        - 'config:search_api.index.default_solr_index'
+        - 'search_api_list:default_solr_index'


### PR DESCRIPTION
This PR installs the [fullcalendar_solr](https://www.drupal.org/project/fullcalendar_solr/) module and provides a calendar view for newspaper collections.

It includes:

- A year calendar view configured with Advanced Search and Facet blocks. The year calendar highlights dates containing newspaper issues for the specified year. When a highlighted date is clicked, it opens a tab to the day view and preserves the search keys and facets.

![image](https://github.com/Islandora-Devops/islandora-starter-site/assets/106131209/917f9fd8-c578-4894-b47c-a40e277ff48f)

- A day view configured with Advanced Search and Facet blocks. The day view displays newspaper issues for a specified date. (Modelled after the Solr search content view)
- A block that generates a link to the calendar view, added to the Newspapers display context. It sets the calendar year to the oldest year with results but this can be modified by editing the sort criteria for the Calendar Link block.

![image](https://github.com/Islandora-Devops/islandora-starter-site/assets/106131209/a5659b6a-e113-42eb-8a84-d3921b73aa1f)