### PR TITLE
Implement Access control with Group

### DIFF
--- a/assets/patches/default_settings.txt
+++ b/assets/patches/default_settings.txt
@@ -1,1 +1,2 @@
 $settings['config_sync_directory'] = '../config/sync';
+$settings['file_private_path'] = 'sites/default/private_files';

--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,10 @@
         "islandora/openseadragon": "^2",
         "islandora/views_nested_details": "^1.0",
         "library/pdf.js": "^2.4",
-        "mjordan/islandora_workbench_integration": "^1.0"
+        "mjordan/islandora_workbench_integration": "^1.0",
+        "digitalutsc/group_solr": "^1.0.0@beta",
+        "digitalutsc/islandora_group": "^1.0.0@beta",
+        "digitalutsc/private_files_adapter": "^1.0.0@beta"
     },
     "conflict": {
         "drupal/drupal": "*",
@@ -127,7 +130,11 @@
                 "type:drupal-custom-theme"
             ]
         },
-        "patches": {}
+        "patches": {
+            "islandora/openseadragon": {
+              "openseadragon.authentication.patch": "https://raw.githubusercontent.com/digitalutsc/private_files_adapter/main/scripts/openseadragon.authentication.patch"
+            }
+        }
     },
     "scripts": {
         "post-root-package-install": ["Islandora\\StarterSite::rootPackageInstall"]

--- a/composer.lock
+++ b/composer.lock
@@ -1318,6 +1318,140 @@
             "time": "2017-01-20T21:14:22+00:00"
         },
         {
+            "name": "digitalutsc/group_solr",
+            "version": "1.0.0-beta1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/digitalutsc/group_solr.git",
+                "reference": "49f0259ce1144c8a7ba9fe449c67dc281d338edf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/digitalutsc/group_solr/zipball/49f0259ce1144c8a7ba9fe449c67dc281d338edf",
+                "reference": "49f0259ce1144c8a7ba9fe449c67dc281d338edf",
+                "shasum": ""
+            },
+            "require": {
+                "drupal/group": "^3.0",
+                "drupal/group_permissions": "^2.0@alpha",
+                "drupal/groupmedia": "^4.0@alpha",
+                "drupal/search_api_solr": "^4.2"
+            },
+            "type": "drupal-module",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "The University of Toronto Scarborough Library's Digital Scholarship Unit (DSU)",
+                    "email": "digitalscholarship@utsc.utoronto.ca",
+                    "role": "Owner"
+                },
+                {
+                    "name": "Kyle Huynh",
+                    "email": "kyle.huynh205@gmail.com",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "This module add Solr indexed field(s) which is determined access control with Group module for an indexed item to be public or private for annonymous users",
+            "homepage": "https://github.com/digitalutsc/group_solr",
+            "support": {
+                "issues": "https://github.com/digitalutsc/group_solr/issues",
+                "source": "https://github.com/digitalutsc/group_solr"
+            },
+            "time": "2023-05-10T13:25:58+00:00"
+        },
+        {
+            "name": "digitalutsc/islandora_group",
+            "version": "1.0.0-beta2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/digitalutsc/islandora_group.git",
+                "reference": "3b1f631025ae24d410677a0db328ee257c7eda73"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/digitalutsc/islandora_group/zipball/3b1f631025ae24d410677a0db328ee257c7eda73",
+                "reference": "3b1f631025ae24d410677a0db328ee257c7eda73",
+                "shasum": ""
+            },
+            "require": {
+                "drupal/group": "^3.1",
+                "drupal/group_permissions": "^2.0@alpha",
+                "drupal/groupmedia": "^4.0@alpha"
+            },
+            "type": "drupal-module",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "The University of Toronto Scarborough Library's Digital Scholarship Unit (DSU)",
+                    "email": "digitalscholarship@utsc.utoronto.ca",
+                    "role": "Owner"
+                },
+                {
+                    "name": "Kyle Huynh",
+                    "email": "kyle.huynh205@gmail.com",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "This module assists to manage access control for node and media with Group module",
+            "homepage": "https://www.drupal.org/project/islandora_group",
+            "support": {
+                "issues": "https://www.drupal.org/project/issues/islandora_group",
+                "source": "http://cgit.drupalcode.org/islandora_group"
+            },
+            "time": "2023-07-06T03:30:10+00:00"
+        },
+        {
+            "name": "digitalutsc/private_files_adapter",
+            "version": "1.0.0-beta2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/digitalutsc/private_files_adapter.git",
+                "reference": "4ac38698d4a6f1e1a36bc6413b6c3ff16f4ff520"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/digitalutsc/private_files_adapter/zipball/4ac38698d4a6f1e1a36bc6413b6c3ff16f4ff520",
+                "reference": "4ac38698d4a6f1e1a36bc6413b6c3ff16f4ff520",
+                "shasum": ""
+            },
+            "require": {
+                "drupal/group": "^3.0",
+                "drupal/group_permissions": "^2.0@alpha",
+                "drupal/groupmedia": "^4.0@alpha",
+                "drupal/jwt": "^2.0"
+            },
+            "type": "drupal-module",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-3.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "The University of Toronto Scarborough Library's Digital Scholarship Unit (DSU)",
+                    "email": "digitalscholarship@utsc.utoronto.ca",
+                    "role": "Owner"
+                },
+                {
+                    "name": "Kyle Huynh",
+                    "email": "kyle.huynh205@gmail.com",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "This module override access control for private file system with Cantaloupe",
+            "homepage": "https://www.drupal.org/project/private_files_adapter",
+            "support": {
+                "issues": "https://www.drupal.org/project/issues/private_files_adapter",
+                "source": "http://cgit.drupalcode.org/private_files_adapter"
+            },
+            "time": "2023-07-06T03:47:03+00:00"
+        },
+        {
             "name": "doctrine/annotations",
             "version": "1.13.3",
             "source": {
@@ -3065,6 +3199,58 @@
             ]
         },
         {
+            "name": "drupal/flexible_permissions",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/flexible_permissions.git",
+                "reference": "1.0.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/flexible_permissions-1.0.0.zip",
+                "reference": "1.0.0",
+                "shasum": "a48740d2edcb04bb0d750c5d5c41ce8fb9acc332"
+            },
+            "require": {
+                "drupal/core": "^9.5 || ^10",
+                "drupal/variationcache": "^1.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "1.0.0",
+                    "datestamp": "1679575763",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Kristiaan Van den Eynde",
+                    "homepage": "https://www.drupal.org/u/kristiaanvandeneynde",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Mathias Wächter",
+                    "homepage": "https://www.drupal.org/u/mef",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "This module allows you to gather, calculate and cache permissions from a myriad of sources",
+            "homepage": "http://drupal.org/project/flexible_permissions",
+            "support": {
+                "source": "https://git.drupalcode.org/project/flexible_permissions",
+                "issues": "https://drupal.org/project/issues/flexible_permissions"
+            }
+        },
+        {
             "name": "drupal/flysystem",
             "version": "2.0.0-beta2",
             "source": {
@@ -3208,6 +3394,161 @@
             "support": {
                 "source": "https://git.drupal.org/project/geolocation.git",
                 "issues": "https://www.drupal.org/project/issues/geolocation"
+            }
+        },
+        {
+            "name": "drupal/group",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/group.git",
+                "reference": "3.1.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/group-3.1.0.zip",
+                "reference": "3.1.0",
+                "shasum": "8f156fa2633f417110268ccb59ac73567fedaa24"
+            },
+            "require": {
+                "drupal/core": "^9.5 || ^10",
+                "drupal/entity": "^1.2",
+                "drupal/flexible_permissions": "^1.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "3.1.0",
+                    "datestamp": "1685092524",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Kristiaan Van den Eynde",
+                    "homepage": "https://www.drupal.org/u/kristiaanvandeneynde",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "kristiaanvandeneynde",
+                    "homepage": "https://www.drupal.org/user/1345130"
+                }
+            ],
+            "description": "This module allows you to group users, content and other entities",
+            "homepage": "http://drupal.org/project/group",
+            "support": {
+                "source": "https://git.drupalcode.org/project/group",
+                "issues": "https://drupal.org/project/issues/group"
+            }
+        },
+        {
+            "name": "drupal/group_permissions",
+            "version": "2.0.0-alpha5",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/group_permissions.git",
+                "reference": "2.0.0-alpha5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/group_permissions-2.0.0-alpha5.zip",
+                "reference": "2.0.0-alpha5",
+                "shasum": "f65294198beb6f9e91f6227915880e1567af2496"
+            },
+            "require": {
+                "drupal/core": "^9 || ^10",
+                "drupal/group": "^2.0 || ^3.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.0.0-alpha5",
+                    "datestamp": "1670262349",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Project has not opted into security advisory coverage!"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Nikolay Lobachev",
+                    "homepage": "https://www.drupal.org/u/lobsterr",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "Group permissions module provides custom permissions per group.",
+            "homepage": "https://github.com/cnect-web/group_permissions",
+            "support": {
+                "source": "https://git.drupalcode.org/project/group_permissions",
+                "issues": "https://www.drupal.org/project/issues/group_permissions"
+            }
+        },
+        {
+            "name": "drupal/groupmedia",
+            "version": "4.0.0-alpha7",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/groupmedia.git",
+                "reference": "4.0.0-alpha7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/groupmedia-4.0.0-alpha7.zip",
+                "reference": "4.0.0-alpha7",
+                "shasum": "6151beeedfad6df32ae208217f5bb1dbfd2045f5"
+            },
+            "require": {
+                "drupal/core": "^9 || ^10",
+                "drupal/group": "^3.0"
+            },
+            "require-dev": {
+                "drupal/paragraphs": "*",
+                "drupal/views_bulk_operations": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "4.0.0-alpha7",
+                    "datestamp": "1683239527",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Alpha releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Artem Dmitriiev",
+                    "homepage": "https://www.drupal.org/u/admitriiev",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Nikolay Lobachev",
+                    "homepage": "https://www.drupal.org/u/lobsterr",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "This module allows you to integrate media entity into group functionality",
+            "homepage": "http://drupal.org/project/groupmedia",
+            "support": {
+                "source": "https://git.drupalcode.org/project/groupmedia",
+                "issues": "https://drupal.org/project/issues/groupmedia"
             }
         },
         {
@@ -4713,6 +5054,57 @@
             "support": {
                 "source": "https://git.drupalcode.org/project/twig_tweak",
                 "issues": "https://www.drupal.org/project/issues/twig_tweak"
+            }
+        },
+        {
+            "name": "drupal/variationcache",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/variationcache.git",
+                "reference": "8.x-1.3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/variationcache-8.x-1.3.zip",
+                "reference": "8.x-1.3",
+                "shasum": "92d1e4f6c2661498bff777f22246bf27d6a03a71"
+            },
+            "require": {
+                "drupal/core": "^9.5 || ^10"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.3",
+                    "datestamp": "1679575893",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Kristiaan Van den Eynde",
+                    "homepage": "https://www.drupal.org/u/kristiaanvandeneynde",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Brad Jones",
+                    "homepage": "https://www.drupal.org/u/bradjones1",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "This project provides VariationCache, a redirect-aware caching implementation.",
+            "homepage": "http://drupal.org/project/variationcache",
+            "support": {
+                "source": "https://git.drupalcode.org/project/variationcache",
+                "issues": "https://drupal.org/project/issues/variationcache"
             }
         },
         {
@@ -11899,7 +12291,10 @@
         "drupal/term_merge": 10,
         "drupal/views_field_view": 10,
         "islandora-rdm/islandora_fits": 20,
-        "islandora/advanced_search": 20
+        "islandora/advanced_search": 20,
+        "digitalutsc/group_solr": 10,
+        "digitalutsc/islandora_group": 10,
+        "digitalutsc/private_files_adapter": 10
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/config/sync/core.entity_form_display.group_relationship.private-group_membership.default.yml
+++ b/config/sync/core.entity_form_display.group_relationship.private-group_membership.default.yml
@@ -1,0 +1,45 @@
+uuid: 6dcdf5f3-918b-4b20-a63d-f9ecd1864c3a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.group_relationship.private-group_membership.group_roles
+    - group.relationship_type.private-group_membership
+  module:
+    - path
+id: group_relationship.private-group_membership.default
+targetEntityType: group_relationship
+bundle: private-group_membership
+mode: default
+content:
+  entity_id:
+    type: entity_reference_autocomplete
+    weight: 5
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  group_roles:
+    type: options_buttons
+    weight: 31
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  uid: true

--- a/config/sync/core.entity_form_display.media.audio.default.yml
+++ b/config/sync/core.entity_form_display.media.audio.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.media.audio.field_access_terms
     - field.field.media.audio.field_file_size
     - field.field.media.audio.field_media_audio_file
     - field.field.media.audio.field_media_of
@@ -27,6 +28,16 @@ content:
     weight: 5
     region: content
     settings: {  }
+    third_party_settings: {  }
+  field_access_terms:
+    type: entity_reference_autocomplete
+    weight: 11
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   field_media_audio_file:
     type: file_generic

--- a/config/sync/core.entity_form_display.media.document.default.yml
+++ b/config/sync/core.entity_form_display.media.document.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.media.document.field_access_terms
     - field.field.media.document.field_file_size
     - field.field.media.document.field_media_document
     - field.field.media.document.field_media_of
@@ -25,6 +26,16 @@ content:
     weight: 5
     region: content
     settings: {  }
+    third_party_settings: {  }
+  field_access_terms:
+    type: entity_reference_autocomplete
+    weight: 9
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   field_media_document:
     type: file_generic
@@ -73,7 +84,7 @@ content:
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 9
+    weight: 8
     region: content
     settings:
       display_label: true

--- a/config/sync/core.entity_form_display.media.extracted_text.default.yml
+++ b/config/sync/core.entity_form_display.media.extracted_text.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.media.extracted_text.field_access_terms
     - field.field.media.extracted_text.field_edited_text
     - field.field.media.extracted_text.field_media_file
     - field.field.media.extracted_text.field_media_of
@@ -25,6 +26,16 @@ content:
     weight: 3
     region: content
     settings: {  }
+    third_party_settings: {  }
+  field_access_terms:
+    type: entity_reference_autocomplete
+    weight: 8
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   field_edited_text:
     type: text_textarea
@@ -75,6 +86,7 @@ content:
     region: content
     settings:
       match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.media.file.default.yml
+++ b/config/sync/core.entity_form_display.media.file.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.media.file.field_access_terms
     - field.field.media.file.field_file_size
     - field.field.media.file.field_media_file
     - field.field.media.file.field_media_of
@@ -22,9 +23,19 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 6
+    weight: 5
     region: content
     settings: {  }
+    third_party_settings: {  }
+  field_access_terms:
+    type: entity_reference_autocomplete
+    weight: 10
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   field_media_file:
     type: file_generic
@@ -35,10 +46,11 @@ content:
     third_party_settings: {  }
   field_media_of:
     type: entity_reference_autocomplete
-    weight: 4
+    weight: 3
     region: content
     settings:
       match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
     third_party_settings: {  }
@@ -50,7 +62,7 @@ content:
     third_party_settings: {  }
   field_original_name:
     type: string_textarea
-    weight: 26
+    weight: 9
     region: content
     settings:
       rows: 5
@@ -66,28 +78,29 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 7
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 8
+    weight: 7
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   translation:
-    weight: 9
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 5
+    weight: 4
     region: content
     settings:
       match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.media.fits_technical_metadata.default.yml
+++ b/config/sync/core.entity_form_display.media.fits_technical_metadata.default.yml
@@ -1,0 +1,83 @@
+uuid: c3770f25-060b-49aa-8cd9-e87c330a1bc2
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.media.fits_technical_metadata.field_access_terms
+    - field.field.media.fits_technical_metadata.field_complete
+    - field.field.media.fits_technical_metadata.field_file_size
+    - field.field.media.fits_technical_metadata.field_media_file
+    - field.field.media.fits_technical_metadata.field_media_of
+    - field.field.media.fits_technical_metadata.field_media_use
+    - field.field.media.fits_technical_metadata.field_mime_type
+    - field.field.media.fits_technical_metadata.fits_ois_file_information_md5che
+    - media.type.fits_technical_metadata
+  module:
+    - path
+id: media.fits_technical_metadata.default
+targetEntityType: media
+bundle: fits_technical_metadata
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 3
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_access_terms:
+    type: entity_reference_autocomplete
+    weight: 6
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 1
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 4
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 5
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 2
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  field_complete: true
+  field_file_size: true
+  field_media_file: true
+  field_media_of: true
+  field_media_use: true
+  field_mime_type: true
+  fits_ois_file_information_md5che: true

--- a/config/sync/core.entity_form_display.media.image.default.yml
+++ b/config/sync/core.entity_form_display.media.image.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.media.image.field_access_terms
     - field.field.media.image.field_file_size
     - field.field.media.image.field_height
     - field.field.media.image.field_media_image
@@ -25,9 +26,19 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 6
+    weight: 5
     region: content
     settings: {  }
+    third_party_settings: {  }
+  field_access_terms:
+    type: entity_reference_autocomplete
+    weight: 10
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   field_media_image:
     type: image_image
@@ -39,10 +50,11 @@ content:
     third_party_settings: {  }
   field_media_of:
     type: entity_reference_autocomplete
-    weight: 4
+    weight: 3
     region: content
     settings:
       match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
     third_party_settings: {  }
@@ -54,7 +66,7 @@ content:
     third_party_settings: {  }
   field_original_name:
     type: string_textarea
-    weight: 26
+    weight: 9
     region: content
     settings:
       rows: 5
@@ -70,28 +82,29 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 7
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 8
+    weight: 7
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   translation:
-    weight: 9
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 5
+    weight: 4
     region: content
     settings:
       match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.media.remote_video.default.yml
+++ b/config/sync/core.entity_form_display.media.remote_video.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.media.remote_video.field_access_terms
     - field.field.media.remote_video.field_media_oembed_video
     - media.type.remote_video
   module:
@@ -17,9 +18,19 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 10
+    weight: 3
     region: content
     settings: {  }
+    third_party_settings: {  }
+  field_access_terms:
+    type: entity_reference_autocomplete
+    weight: 6
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   field_media_oembed_video:
     type: oembed_textfield
@@ -31,27 +42,27 @@ content:
     third_party_settings: {  }
   langcode:
     type: language_select
-    weight: 2
+    weight: 1
     region: content
     settings:
       include_locked: true
     third_party_settings: {  }
   path:
     type: path
-    weight: 30
+    weight: 4
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 100
+    weight: 5
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 5
+    weight: 2
     region: content
     settings:
       match_operator: CONTAINS

--- a/config/sync/core.entity_form_display.media.video.default.yml
+++ b/config/sync/core.entity_form_display.media.video.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.media.video.field_access_terms
     - field.field.media.video.field_file_size
     - field.field.media.video.field_media_of
     - field.field.media.video.field_media_use
@@ -24,16 +25,27 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 6
+    weight: 5
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_media_of:
+  field_access_terms:
     type: entity_reference_autocomplete
-    weight: 4
+    weight: 11
     region: content
     settings:
       match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_media_of:
+    type: entity_reference_autocomplete
+    weight: 3
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
     third_party_settings: {  }
@@ -52,7 +64,7 @@ content:
     third_party_settings: {  }
   field_original_name:
     type: string_textarea
-    weight: 26
+    weight: 9
     region: content
     settings:
       rows: 5
@@ -60,7 +72,7 @@ content:
     third_party_settings: {  }
   field_track:
     type: media_track
-    weight: 27
+    weight: 10
     region: content
     settings:
       progress_indicator: throbber
@@ -75,28 +87,29 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 7
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 8
+    weight: 7
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   translation:
-    weight: 9
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 5
+    weight: 4
     region: content
     settings:
       match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
     third_party_settings: {  }

--- a/config/sync/core.entity_form_display.node.article.default.yml
+++ b/config/sync/core.entity_form_display.node.article.default.yml
@@ -113,4 +113,5 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-hidden: {  }
+hidden:
+  field_access_terms: true

--- a/config/sync/core.entity_form_display.node.islandora_object.default.yml
+++ b/config/sync/core.entity_form_display.node.islandora_object.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.islandora_object.field_abstract
+    - field.field.node.islandora_object.field_access_terms
     - field.field.node.islandora_object.field_alt_title
     - field.field.node.islandora_object.field_classification
     - field.field.node.islandora_object.field_coordinates
@@ -67,6 +68,7 @@ third_party_settings:
         - uid
         - created
         - sticky
+        - field_access_terms
       label: System
       region: content
       parent_name: ''
@@ -253,7 +255,7 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 42
+    weight: 41
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -263,6 +265,16 @@ content:
     region: content
     settings:
       rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_access_terms:
+    type: entity_reference_autocomplete
+    weight: 43
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
       placeholder: ''
     third_party_settings: {  }
   field_alt_title:
@@ -638,21 +650,21 @@ content:
     third_party_settings: {  }
   promote:
     type: boolean_checkbox
-    weight: 40
+    weight: 39
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 39
+    weight: 38
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
-    weight: 43
+    weight: 42
     region: content
     settings:
       display_label: true
@@ -672,7 +684,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 41
+    weight: 40
     region: content
     settings:
       match_operator: CONTAINS

--- a/config/sync/core.entity_form_display.node.page.default.yml
+++ b/config/sync/core.entity_form_display.node.page.default.yml
@@ -83,4 +83,5 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-hidden: {  }
+hidden:
+  field_access_terms: true

--- a/config/sync/core.entity_view_display.group_relationship.private-group_membership.default.yml
+++ b/config/sync/core.entity_view_display.group_relationship.private-group_membership.default.yml
@@ -1,0 +1,25 @@
+uuid: 4a8491f9-56b1-4f58-8a9f-213a8478e528
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.group_relationship.private-group_membership.group_roles
+    - group.relationship_type.private-group_membership
+id: group_relationship.private-group_membership.default
+targetEntityType: group_relationship
+bundle: private-group_membership
+mode: default
+content:
+  group_roles:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: false
+    third_party_settings: {  }
+    weight: -4
+    region: content
+hidden:
+  entity_id: true
+  langcode: true
+  search_api_excerpt: true
+  uid: true

--- a/config/sync/core.entity_view_display.media.audio.default.yml
+++ b/config/sync/core.entity_view_display.media.audio.default.yml
@@ -86,6 +86,7 @@ content:
     region: content
 hidden:
   created: true
+  field_access_terms: true
   field_track: true
   langcode: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.media.audio.file_download.yml
+++ b/config/sync/core.entity_view_display.media.audio.file_download.yml
@@ -32,6 +32,7 @@ content:
     region: content
 hidden:
   created: true
+  field_access_terms: true
   field_file_size: true
   field_gemini_uri: true
   field_media_of: true

--- a/config/sync/core.entity_view_display.media.audio.source.yml
+++ b/config/sync/core.entity_view_display.media.audio.source.yml
@@ -39,6 +39,7 @@ content:
     region: content
 hidden:
   created: true
+  field_access_terms: true
   field_file_size: true
   field_media_of: true
   field_media_use: true

--- a/config/sync/core.entity_view_display.media.document.default.yml
+++ b/config/sync/core.entity_view_display.media.document.default.yml
@@ -82,6 +82,7 @@ content:
     region: content
 hidden:
   created: true
+  field_access_terms: true
   langcode: true
   search_api_excerpt: true
   thumbnail: true

--- a/config/sync/core.entity_view_display.media.document.file_download.yml
+++ b/config/sync/core.entity_view_display.media.document.file_download.yml
@@ -36,6 +36,7 @@ content:
     region: content
 hidden:
   created: true
+  field_access_terms: true
   field_file_size: true
   field_media_of: true
   field_media_use: true

--- a/config/sync/core.entity_view_display.media.document.pdfjs.yml
+++ b/config/sync/core.entity_view_display.media.document.pdfjs.yml
@@ -36,6 +36,7 @@ content:
     region: content
 hidden:
   created: true
+  field_access_terms: true
   field_file_size: true
   field_gemini_uri: true
   field_media_of: true

--- a/config/sync/core.entity_view_display.media.document.source.yml
+++ b/config/sync/core.entity_view_display.media.document.source.yml
@@ -30,6 +30,7 @@ content:
     region: content
 hidden:
   created: true
+  field_access_terms: true
   field_file_size: true
   field_gemini_uri: true
   field_media_of: true

--- a/config/sync/core.entity_view_display.media.extracted_text.default.yml
+++ b/config/sync/core.entity_view_display.media.extracted_text.default.yml
@@ -61,6 +61,7 @@ content:
     weight: 0
     region: content
 hidden:
+  field_access_terms: true
   field_media_use: true
   field_mime_type: true
   langcode: true

--- a/config/sync/core.entity_view_display.media.file.default.yml
+++ b/config/sync/core.entity_view_display.media.file.default.yml
@@ -82,6 +82,7 @@ content:
     region: content
 hidden:
   created: true
+  field_access_terms: true
   langcode: true
   search_api_excerpt: true
   thumbnail: true

--- a/config/sync/core.entity_view_display.media.file.file_download.yml
+++ b/config/sync/core.entity_view_display.media.file.file_download.yml
@@ -31,6 +31,7 @@ content:
     region: content
 hidden:
   created: true
+  field_access_terms: true
   field_file_size: true
   field_gemini_uri: true
   field_media_of: true

--- a/config/sync/core.entity_view_display.media.file.open_seadragon.yml
+++ b/config/sync/core.entity_view_display.media.file.open_seadragon.yml
@@ -29,6 +29,7 @@ content:
     region: content
 hidden:
   created: true
+  field_access_terms: true
   field_file_size: true
   field_gemini_uri: true
   field_media_of: true

--- a/config/sync/core.entity_view_display.media.file.pdfjs.yml
+++ b/config/sync/core.entity_view_display.media.file.pdfjs.yml
@@ -36,6 +36,7 @@ content:
     region: content
 hidden:
   created: true
+  field_access_terms: true
   field_file_size: true
   field_gemini_uri: true
   field_media_of: true

--- a/config/sync/core.entity_view_display.media.file.source.yml
+++ b/config/sync/core.entity_view_display.media.file.source.yml
@@ -30,6 +30,7 @@ content:
     region: content
 hidden:
   created: true
+  field_access_terms: true
   field_file_size: true
   field_gemini_uri: true
   field_media_of: true

--- a/config/sync/core.entity_view_display.media.fits_technical_metadata.default.yml
+++ b/config/sync/core.entity_view_display.media.fits_technical_metadata.default.yml
@@ -53,6 +53,7 @@ content:
     region: content
 hidden:
   created: true
+  field_access_terms: true
   field_complete: true
   field_file_size: true
   fits_ois_file_information_md5che: true

--- a/config/sync/core.entity_view_display.media.fits_technical_metadata.fits_technical_metadata.yml
+++ b/config/sync/core.entity_view_display.media.fits_technical_metadata.fits_technical_metadata.yml
@@ -60,6 +60,7 @@ content:
     weight: 0
     region: content
 hidden:
+  field_access_terms: true
   field_complete: true
   field_file_size: true
   field_media_of: true

--- a/config/sync/core.entity_view_display.media.image.default.yml
+++ b/config/sync/core.entity_view_display.media.image.default.yml
@@ -106,6 +106,7 @@ content:
     region: content
 hidden:
   created: true
+  field_access_terms: true
   langcode: true
   search_api_excerpt: true
   thumbnail: true

--- a/config/sync/core.entity_view_display.media.image.file_download.yml
+++ b/config/sync/core.entity_view_display.media.image.file_download.yml
@@ -33,6 +33,7 @@ content:
     region: content
 hidden:
   created: true
+  field_access_terms: true
   field_file_size: true
   field_gemini_uri: true
   field_height: true

--- a/config/sync/core.entity_view_display.media.image.open_seadragon.yml
+++ b/config/sync/core.entity_view_display.media.image.open_seadragon.yml
@@ -31,6 +31,7 @@ content:
     region: content
 hidden:
   created: true
+  field_access_terms: true
   field_file_size: true
   field_gemini_uri: true
   field_height: true

--- a/config/sync/core.entity_view_display.media.image.source.yml
+++ b/config/sync/core.entity_view_display.media.image.source.yml
@@ -33,6 +33,7 @@ content:
     region: content
 hidden:
   created: true
+  field_access_terms: true
   field_file_size: true
   field_gemini_uri: true
   field_height: true

--- a/config/sync/core.entity_view_display.media.image.thumbnail.yml
+++ b/config/sync/core.entity_view_display.media.image.thumbnail.yml
@@ -36,6 +36,7 @@ content:
     region: content
 hidden:
   created: true
+  field_access_terms: true
   field_file_size: true
   field_gemini_uri: true
   field_height: true

--- a/config/sync/core.entity_view_display.media.video.default.yml
+++ b/config/sync/core.entity_view_display.media.video.default.yml
@@ -89,6 +89,7 @@ content:
     region: content
 hidden:
   created: true
+  field_access_terms: true
   field_track: true
   langcode: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.media.video.file_download.yml
+++ b/config/sync/core.entity_view_display.media.video.file_download.yml
@@ -32,6 +32,7 @@ content:
     region: content
 hidden:
   created: true
+  field_access_terms: true
   field_file_size: true
   field_gemini_uri: true
   field_media_of: true

--- a/config/sync/core.entity_view_display.media.video.source.yml
+++ b/config/sync/core.entity_view_display.media.video.source.yml
@@ -42,6 +42,7 @@ content:
     region: content
 hidden:
   created: true
+  field_access_terms: true
   field_file_size: true
   field_media_of: true
   field_media_use: true

--- a/config/sync/core.entity_view_display.node.article.default.yml
+++ b/config/sync/core.entity_view_display.node.article.default.yml
@@ -83,5 +83,6 @@ content:
     weight: 100
     region: content
 hidden:
+  field_access_terms: true
   langcode: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.article.rss.yml
+++ b/config/sync/core.entity_view_display.node.article.rss.yml
@@ -44,6 +44,7 @@ content:
 hidden:
   body: true
   comment: true
+  field_access_terms: true
   field_image: true
   field_tags: true
   langcode: true

--- a/config/sync/core.entity_view_display.node.article.teaser.yml
+++ b/config/sync/core.entity_view_display.node.article.teaser.yml
@@ -73,6 +73,7 @@ content:
     region: content
 hidden:
   comment: true
+  field_access_terms: true
   field_image: true
   field_tags: true
   langcode: true

--- a/config/sync/core.entity_view_display.node.islandora_object.default.yml
+++ b/config/sync/core.entity_view_display.node.islandora_object.default.yml
@@ -427,6 +427,7 @@ content:
 hidden:
   display_media_entity_view_3: true
   display_media_thumbnail: true
+  field_access_terms: true
   field_model: true
   field_pid: true
   field_place_published_country: true

--- a/config/sync/core.entity_view_display.node.islandora_object.search_index.yml
+++ b/config/sync/core.entity_view_display.node.islandora_object.search_index.yml
@@ -428,6 +428,7 @@ content:
 hidden:
   display_media_entity_view_3: true
   display_media_thumbnail: true
+  field_access_terms: true
   field_model: true
   field_pid: true
   field_place_published_country: true

--- a/config/sync/core.entity_view_display.node.islandora_object.search_result.yml
+++ b/config/sync/core.entity_view_display.node.islandora_object.search_result.yml
@@ -168,6 +168,7 @@ hidden:
   display_media_original_download: true
   display_media_service_file: true
   display_media_thumbnail: true
+  field_access_terms: true
   field_alt_title: true
   field_classification: true
   field_coordinates: true

--- a/config/sync/core.entity_view_display.node.islandora_object.teaser.yml
+++ b/config/sync/core.entity_view_display.node.islandora_object.teaser.yml
@@ -121,6 +121,7 @@ hidden:
   display_media_original_download: true
   display_media_service_file: true
   display_media_thumbnail: true
+  field_access_terms: true
   field_alt_title: true
   field_classification: true
   field_coordinates: true

--- a/config/sync/core.entity_view_display.node.page.default.yml
+++ b/config/sync/core.entity_view_display.node.page.default.yml
@@ -46,5 +46,6 @@ content:
     weight: 101
     region: content
 hidden:
+  field_access_terms: true
   langcode: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.page.teaser.yml
+++ b/config/sync/core.entity_view_display.node.page.teaser.yml
@@ -48,5 +48,6 @@ content:
     weight: 101
     region: content
 hidden:
+  field_access_terms: true
   langcode: true
   search_api_excerpt: true

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -30,6 +30,7 @@ module:
   devel: 0
   dynamic_page_cache: 0
   editor: 0
+  entity: 0
   eva: 0
   facets: 0
   facets_summary: 0
@@ -44,8 +45,13 @@ module:
   file_replace: 0
   filehash: 0
   filter: 0
+  flexible_permissions: 0
   flysystem: 0
   geolocation: 0
+  gnode: 0
+  group: 0
+  group_permissions: 0
+  groupmedia: 0
   hal: 0
   help: 0
   history: 0
@@ -55,6 +61,7 @@ module:
   islandora_breadcrumbs: 0
   islandora_core_feature: 0
   islandora_fits: 0
+  islandora_group: 0
   islandora_iiif: 0
   islandora_image: 0
   islandora_text_extraction: 0
@@ -69,6 +76,8 @@ module:
   jquery_ui_touch_punch: 0
   jsonld: 0
   jwt: 0
+  jwt_auth_consumer: 0
+  jwt_auth_issuer: 0
   key: 0
   language: 0
   link: 0
@@ -112,10 +121,13 @@ module:
   twig_tweak: 0
   update: 0
   user: 0
+  variationcache: 0
   views_data_export: 0
   views_field_view: 0
   views_nested_details: 0
   views_ui: 0
+  group_solr: 1
+  private_files_adapter: 1
   content_translation: 10
   views: 10
   minimal: 1000

--- a/config/sync/field.field.group_relationship.private-group_membership.group_roles.yml
+++ b/config/sync/field.field.group_relationship.private-group_membership.group_roles.yml
@@ -1,0 +1,22 @@
+uuid: 0d5d317d-f1af-49ae-a389-cad05c010356
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.group_relationship.group_roles
+    - group.relationship_type.private-group_membership
+id: group_relationship.private-group_membership.group_roles
+field_name: group_roles
+entity_type: group_relationship
+bundle: private-group_membership
+label: Roles
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'group_type:group_role'
+  handler_settings:
+    group_type_id: private
+field_type: entity_reference

--- a/config/sync/field.field.media.audio.field_access_terms.yml
+++ b/config/sync/field.field.media.audio.field_access_terms.yml
@@ -1,0 +1,29 @@
+uuid: 28846c08-0925-49f7-b788-bee1f7642c4c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_access_terms
+    - media.type.audio
+    - taxonomy.vocabulary.islandora_access
+id: media.audio.field_access_terms
+field_name: field_access_terms
+entity_type: media
+bundle: audio
+label: 'Access Terms'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      islandora_access: islandora_access
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.media.document.field_access_terms.yml
+++ b/config/sync/field.field.media.document.field_access_terms.yml
@@ -1,0 +1,29 @@
+uuid: d56b37f8-3b6a-4f05-a93e-8ec2670b8186
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_access_terms
+    - media.type.document
+    - taxonomy.vocabulary.islandora_access
+id: media.document.field_access_terms
+field_name: field_access_terms
+entity_type: media
+bundle: document
+label: 'Access Terms'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      islandora_access: islandora_access
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.media.extracted_text.field_access_terms.yml
+++ b/config/sync/field.field.media.extracted_text.field_access_terms.yml
@@ -1,0 +1,29 @@
+uuid: 9ccfeb7b-0f4c-488e-bb85-0f74e951793c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_access_terms
+    - media.type.extracted_text
+    - taxonomy.vocabulary.islandora_access
+id: media.extracted_text.field_access_terms
+field_name: field_access_terms
+entity_type: media
+bundle: extracted_text
+label: 'Access Terms'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      islandora_access: islandora_access
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.media.file.field_access_terms.yml
+++ b/config/sync/field.field.media.file.field_access_terms.yml
@@ -1,0 +1,29 @@
+uuid: ece06e12-fd3e-4e22-9ab2-7566b9d04cb3
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_access_terms
+    - media.type.file
+    - taxonomy.vocabulary.islandora_access
+id: media.file.field_access_terms
+field_name: field_access_terms
+entity_type: media
+bundle: file
+label: 'Access Terms'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      islandora_access: islandora_access
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.media.fits_technical_metadata.field_access_terms.yml
+++ b/config/sync/field.field.media.fits_technical_metadata.field_access_terms.yml
@@ -1,0 +1,29 @@
+uuid: 2d2c849b-3f6d-42fd-a245-1a25aa0d7067
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_access_terms
+    - media.type.fits_technical_metadata
+    - taxonomy.vocabulary.islandora_access
+id: media.fits_technical_metadata.field_access_terms
+field_name: field_access_terms
+entity_type: media
+bundle: fits_technical_metadata
+label: 'Access Terms'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      islandora_access: islandora_access
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.media.image.field_access_terms.yml
+++ b/config/sync/field.field.media.image.field_access_terms.yml
@@ -1,0 +1,29 @@
+uuid: bf003cf8-ebbc-4c73-bc99-0199645d7bf8
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_access_terms
+    - media.type.image
+    - taxonomy.vocabulary.islandora_access
+id: media.image.field_access_terms
+field_name: field_access_terms
+entity_type: media
+bundle: image
+label: 'Access Terms'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      islandora_access: islandora_access
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.media.remote_video.field_access_terms.yml
+++ b/config/sync/field.field.media.remote_video.field_access_terms.yml
@@ -1,0 +1,29 @@
+uuid: bc5b3dcc-9938-40a9-a331-7b5569d95a06
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_access_terms
+    - media.type.remote_video
+    - taxonomy.vocabulary.islandora_access
+id: media.remote_video.field_access_terms
+field_name: field_access_terms
+entity_type: media
+bundle: remote_video
+label: 'Access Terms'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      islandora_access: islandora_access
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.media.video.field_access_terms.yml
+++ b/config/sync/field.field.media.video.field_access_terms.yml
@@ -1,0 +1,29 @@
+uuid: b226ad15-1470-42d1-b27b-538ba57acd08
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_access_terms
+    - media.type.video
+    - taxonomy.vocabulary.islandora_access
+id: media.video.field_access_terms
+field_name: field_access_terms
+entity_type: media
+bundle: video
+label: 'Access Terms'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      islandora_access: islandora_access
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.node.article.field_access_terms.yml
+++ b/config/sync/field.field.node.article.field_access_terms.yml
@@ -1,0 +1,29 @@
+uuid: a9a3f30f-b2d5-4ae0-83a0-53ade9cc8b0b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_access_terms
+    - node.type.article
+    - taxonomy.vocabulary.islandora_access
+id: node.article.field_access_terms
+field_name: field_access_terms
+entity_type: node
+bundle: article
+label: 'Access Terms'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      islandora_access: islandora_access
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.node.islandora_object.field_access_terms.yml
+++ b/config/sync/field.field.node.islandora_object.field_access_terms.yml
@@ -1,0 +1,29 @@
+uuid: b20e4f2d-df1b-45db-b145-54a49ad290a5
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_access_terms
+    - node.type.islandora_object
+    - taxonomy.vocabulary.islandora_access
+id: node.islandora_object.field_access_terms
+field_name: field_access_terms
+entity_type: node
+bundle: islandora_object
+label: 'Access Terms'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      islandora_access: islandora_access
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.node.page.field_access_terms.yml
+++ b/config/sync/field.field.node.page.field_access_terms.yml
@@ -1,0 +1,29 @@
+uuid: 269fb686-55ac-471f-96ee-c4d1136abd0a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_access_terms
+    - node.type.page
+    - taxonomy.vocabulary.islandora_access
+id: node.page.field_access_terms
+field_name: field_access_terms
+entity_type: node
+bundle: page
+label: 'Access Terms'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      islandora_access: islandora_access
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.storage.group_relationship.group_roles.yml
+++ b/config/sync/field.storage.group_relationship.group_roles.yml
@@ -1,0 +1,19 @@
+uuid: 8f07724e-3796-4962-b236-49cf45f458a6
+langcode: en
+status: true
+dependencies:
+  module:
+    - group
+id: group_relationship.group_roles
+field_name: group_roles
+entity_type: group_relationship
+type: entity_reference
+settings:
+  target_type: group_role
+module: core
+locked: true
+cardinality: -1
+translatable: false
+indexes: {  }
+persist_with_no_fields: true
+custom_storage: false

--- a/config/sync/field.storage.media.field_access_terms.yml
+++ b/config/sync/field.storage.media.field_access_terms.yml
@@ -1,0 +1,24 @@
+uuid: 2ecb1121-ce0a-49a4-b192-f5ceb8f375d1
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - media
+    - taxonomy
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: media.field_access_terms
+field_name: field_access_terms
+entity_type: media
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_access_terms.yml
+++ b/config/sync/field.storage.node.field_access_terms.yml
@@ -1,0 +1,24 @@
+uuid: 4f70aea0-71dc-468b-8508-28a040d24c28
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - node
+    - taxonomy
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: node.field_access_terms
+field_name: field_access_terms
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/group.relationship_type.private-b46d5f39e98b2e6c52d1d6c0.yml
+++ b/config/sync/group.relationship_type.private-b46d5f39e98b2e6c52d1d6c0.yml
@@ -1,0 +1,17 @@
+uuid: 952ceb90-d7b3-4df0-bbe8-17fbcb061d1d
+langcode: en
+status: true
+dependencies:
+  config:
+    - group.type.private
+    - media.type.fits_technical_metadata
+  module:
+    - groupmedia
+    - media
+id: private-b46d5f39e98b2e6c52d1d6c0
+group_type: private
+content_plugin: 'group_media:fits_technical_metadata'
+plugin_config:
+  group_cardinality: 0
+  entity_cardinality: 1
+  use_creation_wizard: true

--- a/config/sync/group.relationship_type.private-b991edb10f3dfafa0131bb91.yml
+++ b/config/sync/group.relationship_type.private-b991edb10f3dfafa0131bb91.yml
@@ -1,0 +1,17 @@
+uuid: 18d684f7-eed3-4dcd-b21b-c4e2a51390df
+langcode: en
+status: true
+dependencies:
+  config:
+    - group.type.private
+    - node.type.islandora_object
+  module:
+    - gnode
+    - node
+id: private-b991edb10f3dfafa0131bb91
+group_type: private
+content_plugin: 'group_node:islandora_object'
+plugin_config:
+  group_cardinality: 0
+  entity_cardinality: 1
+  use_creation_wizard: true

--- a/config/sync/group.relationship_type.private-e72de7418a773fdb5a3b438d.yml
+++ b/config/sync/group.relationship_type.private-e72de7418a773fdb5a3b438d.yml
@@ -1,0 +1,17 @@
+uuid: 6bedaadd-e6d6-4cad-a867-9740d5ae45ce
+langcode: en
+status: true
+dependencies:
+  config:
+    - group.type.private
+    - media.type.extracted_text
+  module:
+    - groupmedia
+    - media
+id: private-e72de7418a773fdb5a3b438d
+group_type: private
+content_plugin: 'group_media:extracted_text'
+plugin_config:
+  group_cardinality: 0
+  entity_cardinality: 1
+  use_creation_wizard: true

--- a/config/sync/group.relationship_type.private-group_media-audio.yml
+++ b/config/sync/group.relationship_type.private-group_media-audio.yml
@@ -1,0 +1,17 @@
+uuid: de94b36a-89d1-4598-9ed4-2d4112dd3451
+langcode: en
+status: true
+dependencies:
+  config:
+    - group.type.private
+    - media.type.audio
+  module:
+    - groupmedia
+    - media
+id: private-group_media-audio
+group_type: private
+content_plugin: 'group_media:audio'
+plugin_config:
+  group_cardinality: 0
+  entity_cardinality: 1
+  use_creation_wizard: true

--- a/config/sync/group.relationship_type.private-group_media-document.yml
+++ b/config/sync/group.relationship_type.private-group_media-document.yml
@@ -1,0 +1,17 @@
+uuid: 8f5c05dd-7dfb-4663-b352-3d4a46bb57da
+langcode: en
+status: true
+dependencies:
+  config:
+    - group.type.private
+    - media.type.document
+  module:
+    - groupmedia
+    - media
+id: private-group_media-document
+group_type: private
+content_plugin: 'group_media:document'
+plugin_config:
+  group_cardinality: 0
+  entity_cardinality: 1
+  use_creation_wizard: true

--- a/config/sync/group.relationship_type.private-group_media-file.yml
+++ b/config/sync/group.relationship_type.private-group_media-file.yml
@@ -1,0 +1,17 @@
+uuid: 104e68d6-6cfd-49db-b4d6-4112713d6cc7
+langcode: en
+status: true
+dependencies:
+  config:
+    - group.type.private
+    - media.type.file
+  module:
+    - groupmedia
+    - media
+id: private-group_media-file
+group_type: private
+content_plugin: 'group_media:file'
+plugin_config:
+  group_cardinality: 0
+  entity_cardinality: 1
+  use_creation_wizard: true

--- a/config/sync/group.relationship_type.private-group_media-image.yml
+++ b/config/sync/group.relationship_type.private-group_media-image.yml
@@ -1,0 +1,17 @@
+uuid: fe3923a4-fbeb-450d-8d13-e9131e384bd2
+langcode: en
+status: true
+dependencies:
+  config:
+    - group.type.private
+    - media.type.image
+  module:
+    - groupmedia
+    - media
+id: private-group_media-image
+group_type: private
+content_plugin: 'group_media:image'
+plugin_config:
+  group_cardinality: 0
+  entity_cardinality: 1
+  use_creation_wizard: true

--- a/config/sync/group.relationship_type.private-group_media-remote_video.yml
+++ b/config/sync/group.relationship_type.private-group_media-remote_video.yml
@@ -1,0 +1,17 @@
+uuid: ffe1db65-f2f1-4d21-8cfd-a246778c81be
+langcode: en
+status: true
+dependencies:
+  config:
+    - group.type.private
+    - media.type.remote_video
+  module:
+    - groupmedia
+    - media
+id: private-group_media-remote_video
+group_type: private
+content_plugin: 'group_media:remote_video'
+plugin_config:
+  group_cardinality: 0
+  entity_cardinality: 1
+  use_creation_wizard: true

--- a/config/sync/group.relationship_type.private-group_media-video.yml
+++ b/config/sync/group.relationship_type.private-group_media-video.yml
@@ -1,0 +1,17 @@
+uuid: 4d4bfa6c-8f1b-4d93-9e4c-dff8d62388f9
+langcode: en
+status: true
+dependencies:
+  config:
+    - group.type.private
+    - media.type.video
+  module:
+    - groupmedia
+    - media
+id: private-group_media-video
+group_type: private
+content_plugin: 'group_media:video'
+plugin_config:
+  group_cardinality: 0
+  entity_cardinality: 1
+  use_creation_wizard: true

--- a/config/sync/group.relationship_type.private-group_media_type.yml
+++ b/config/sync/group.relationship_type.private-group_media_type.yml
@@ -1,0 +1,16 @@
+uuid: 97488338-1f8a-4b99-b7bd-fb35681fef86
+langcode: en
+status: true
+dependencies:
+  config:
+    - group.type.private
+  module:
+    - groupmedia
+    - media
+id: private-group_media_type
+group_type: private
+content_plugin: group_media_type
+plugin_config:
+  group_cardinality: 0
+  entity_cardinality: 0
+  use_creation_wizard: false

--- a/config/sync/group.relationship_type.private-group_membership.yml
+++ b/config/sync/group.relationship_type.private-group_membership.yml
@@ -1,0 +1,15 @@
+uuid: 81ae2619-0c4c-4f3c-9e30-de146b170709
+langcode: en
+status: true
+dependencies:
+  config:
+    - group.type.private
+  module:
+    - user
+id: private-group_membership
+group_type: private
+content_plugin: group_membership
+plugin_config:
+  group_cardinality: 0
+  entity_cardinality: 1
+  use_creation_wizard: false

--- a/config/sync/group.role.private-admin.yml
+++ b/config/sync/group.role.private-admin.yml
@@ -1,0 +1,15 @@
+uuid: 7aad61d0-fee0-4542-93c4-8a4ca27e0801
+langcode: en
+status: true
+dependencies:
+  config:
+    - group.type.private
+    - user.role.administrator
+id: private-admin
+label: Admin
+weight: -99
+admin: true
+scope: insider
+global_role: administrator
+group_type: private
+permissions: {  }

--- a/config/sync/group.role.private-anonymous.yml
+++ b/config/sync/group.role.private-anonymous.yml
@@ -1,0 +1,15 @@
+uuid: d5f9542e-f9b4-452d-99bc-56f9b9d7103b
+langcode: en
+status: true
+dependencies:
+  config:
+    - group.type.private
+    - user.role.anonymous
+id: private-anonymous
+label: Anonymous
+weight: -102
+admin: false
+scope: outsider
+global_role: anonymous
+group_type: private
+permissions: {  }

--- a/config/sync/group.role.private-fedora_admin.yml
+++ b/config/sync/group.role.private-fedora_admin.yml
@@ -1,0 +1,15 @@
+uuid: adff3e07-9e00-44da-9f03-14a43c578091
+langcode: en
+status: true
+dependencies:
+  config:
+    - group.type.private
+    - user.role.fedoraadmin
+id: private-fedora_admin
+label: 'Fedora Admin'
+weight: -98
+admin: true
+scope: insider
+global_role: fedoraadmin
+group_type: private
+permissions: {  }

--- a/config/sync/group.role.private-member.yml
+++ b/config/sync/group.role.private-member.yml
@@ -1,0 +1,47 @@
+uuid: ef0f6bdb-99ce-49c4-8cfe-9b12e4d5ab33
+langcode: en
+status: true
+dependencies:
+  config:
+    - group.type.private
+    - user.role.authenticated
+id: private-member
+label: Member
+weight: -100
+admin: false
+scope: insider
+global_role: authenticated
+group_type: private
+permissions:
+  - 'update any group_media:audio entity'
+  - 'update any group_media:document entity'
+  - 'update any group_media:file entity'
+  - 'update any group_media:image entity'
+  - 'update any group_media:remote_video entity'
+  - 'update any group_media:video entity'
+  - 'update any group_media:web_archive entity'
+  - 'update any group_node:islandora_object entity'
+  - 'update own group_media:audio entity'
+  - 'update own group_media:document entity'
+  - 'update own group_media:file entity'
+  - 'update own group_media:image entity'
+  - 'update own group_media:remote_video entity'
+  - 'update own group_media:video entity'
+  - 'update own group_media:web_archive entity'
+  - 'update own group_node:islandora_object entity'
+  - 'view group_media:audio entity'
+  - 'view group_media:document entity'
+  - 'view group_media:file entity'
+  - 'view group_media:image entity'
+  - 'view group_media:remote_video entity'
+  - 'view group_media:video entity'
+  - 'view group_media:web_archive entity'
+  - 'view group_node:islandora_object entity'
+  - 'view unpublished group_media:audio entity'
+  - 'view unpublished group_media:document entity'
+  - 'view unpublished group_media:file entity'
+  - 'view unpublished group_media:image entity'
+  - 'view unpublished group_media:remote_video entity'
+  - 'view unpublished group_media:video entity'
+  - 'view unpublished group_media:web_archive entity'
+  - 'view unpublished group_node:islandora_object entity'

--- a/config/sync/group.role.private-outsider.yml
+++ b/config/sync/group.role.private-outsider.yml
@@ -1,0 +1,16 @@
+uuid: 1dd2aa6f-4a7e-47d2-b51e-8aa7c9e9eca7
+langcode: en
+status: true
+dependencies:
+  config:
+    - group.type.private
+    - user.role.authenticated
+id: private-outsider
+label: Outsider
+weight: -101
+admin: false
+scope: outsider
+global_role: authenticated
+group_type: private
+permissions:
+  - 'view group_node:islandora_object entity'

--- a/config/sync/group.type.private.yml
+++ b/config/sync/group.type.private.yml
@@ -1,0 +1,12 @@
+uuid: 89a4b89c-6b95-4f20-9587-051f64178465
+langcode: en
+status: true
+dependencies: {  }
+id: private
+label: Private
+description: 'This group type is meant for groups which have access control applied for them. '
+new_revision: true
+creator_membership: true
+creator_wizard: true
+creator_roles:
+  - private-admin

--- a/config/sync/islandora_group.config.yml
+++ b/config/sync/islandora_group.config.yml
@@ -1,0 +1,14 @@
+private: islandora_access
+node-type-access-fields:
+  article: field_access_terms
+  islandora_object: field_access_terms
+  page: field_access_terms
+media-type-access-fields:
+  audio: field_access_terms
+  document: field_access_terms
+  extracted_text: field_access_terms
+  file: field_access_terms
+  fits_technical_metadata: field_access_terms
+  image: field_access_terms
+  remote_video: field_access_terms
+  video: field_access_terms

--- a/config/sync/key.key.islandora_rsa_key.yml
+++ b/config/sync/key.key.islandora_rsa_key.yml
@@ -12,6 +12,6 @@ key_type_settings:
   algorithm: RS256
 key_provider: file
 key_provider_settings:
-  file_location: /opt/islandora/auth/private.key
+  file_location: /opt/keys/jwt/private.key
 key_input: none
 key_input_settings: {  }

--- a/config/sync/media.settings.yml
+++ b/config/sync/media.settings.yml
@@ -3,4 +3,4 @@ _core:
 icon_base_uri: 'public://media-icons/generic'
 iframe_domain: ''
 oembed_providers_url: 'https://oembed.com/providers.json'
-standalone_url: false
+standalone_url: true

--- a/config/sync/search_api.index.default_solr_index.yml
+++ b/config/sync/search_api.index.default_solr_index.yml
@@ -34,6 +34,7 @@ dependencies:
     - taxonomy
     - search_api
     - controlled_access_terms
+    - group_solr
 third_party_settings:
   search_api_solr:
     finalize: false
@@ -250,6 +251,10 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.field_tags
+  group_access_control:
+    label: ' Group: Access Control'
+    property_path: search_api_group_access_control
+    type: string
   linked_agent_name_fulltext:
     label: Names
     datasource_id: 'entity:node'
@@ -477,6 +482,7 @@ processor_settings:
     weights:
       preprocess_index: -10
   entity_type: {  }
+  group_access_control: {  }
   hierarchy:
     weights:
       preprocess_index: -45

--- a/config/sync/system.action.audio_generate_a_service_file_from_an_original_file.yml
+++ b/config/sync/system.action.audio_generate_a_service_file_from_an_original_file.yml
@@ -18,5 +18,5 @@ configuration:
   derivative_term_uri: 'http://pcdm.org/use#ServiceFile'
   mimetype: audio/mpeg
   args: '-codec:a libmp3lame -q:a 5'
-  scheme: public
+  scheme: private
   path: '[date:custom:Y]-[date:custom:m]/[node:nid]-[term:name].mp3'

--- a/config/sync/system.action.digital_document_generate_a_thumbnail_from_an_original_file.yml
+++ b/config/sync/system.action.digital_document_generate_a_thumbnail_from_an_original_file.yml
@@ -18,5 +18,5 @@ configuration:
   derivative_term_uri: 'http://pcdm.org/use#ThumbnailImage'
   mimetype: image/png
   args: '-thumbnail 100x100'
-  scheme: public
+  scheme: private
   path: '[date:custom:Y]-[date:custom:m]/[node:nid]-[term:name].png'

--- a/config/sync/system.action.generate_a_technical_metadata_derivative.yml
+++ b/config/sync/system.action.generate_a_technical_metadata_derivative.yml
@@ -18,5 +18,5 @@ configuration:
   mimetype: application/xml
   args: null
   destination_media_type: fits_technical_metadata
-  scheme: public
+  scheme: private
   path: '[date:custom:Y]-[date:custom:m]/[node:nid]-[term:name].xml'

--- a/config/sync/system.action.image_generate_a_service_file_from_an_original_file.yml
+++ b/config/sync/system.action.image_generate_a_service_file_from_an_original_file.yml
@@ -18,5 +18,5 @@ configuration:
   derivative_term_uri: 'http://pcdm.org/use#ServiceFile'
   mimetype: image/jpeg
   args: ''
-  scheme: public
+  scheme: private
   path: '[date:custom:Y]-[date:custom:m]/[node:nid]-[term:name].jpg'

--- a/config/sync/system.action.image_generate_a_thumbnail_from_an_original_file.yml
+++ b/config/sync/system.action.image_generate_a_thumbnail_from_an_original_file.yml
@@ -18,5 +18,5 @@ configuration:
   derivative_term_uri: 'http://pcdm.org/use#ThumbnailImage'
   mimetype: image/jpeg
   args: '-thumbnail 220x220'
-  scheme: public
+  scheme: private
   path: '[date:custom:Y]-[date:custom:m]/[node:nid]-[term:name].jpg'

--- a/config/sync/system.action.video_generate_a_service_file_from_an_original_file.yml
+++ b/config/sync/system.action.video_generate_a_service_file_from_an_original_file.yml
@@ -18,5 +18,5 @@ configuration:
   derivative_term_uri: 'http://pcdm.org/use#ServiceFile'
   mimetype: video/mp4
   args: ''
-  scheme: public
+  scheme: private
   path: '[date:custom:Y]-[date:custom:m]/[node:nid]-[term:name].mp4'

--- a/config/sync/system.action.video_generate_a_thumbnail_at_0_00_03.yml
+++ b/config/sync/system.action.video_generate_a_thumbnail_at_0_00_03.yml
@@ -16,5 +16,5 @@ configuration:
   derivative_term_uri: 'http://pcdm.org/use#ThumbnailImage'
   mimetype: image/jpeg
   args: '-ss 00:00:03.000 -frames 1 -vf scale=100:-2'
-  scheme: public
+  scheme: private
   path: '[date:custom:Y]-[date:custom:m]/[node:nid].jpg'

--- a/config/sync/system.action.video_generate_a_thumbnail_from_an_original_file.yml
+++ b/config/sync/system.action.video_generate_a_thumbnail_from_an_original_file.yml
@@ -18,5 +18,5 @@ configuration:
   derivative_term_uri: 'http://pcdm.org/use#ThumbnailImage'
   mimetype: image/jpeg
   args: '-ss 00:00:01.000 -frames 1 -vf scale=100:-2'
-  scheme: public
+  scheme: private
   path: '[date:custom:Y]-[date:custom:m]/[node:nid]-[term:name].jpg'

--- a/config/sync/system.file.yml
+++ b/config/sync/system.file.yml
@@ -1,5 +1,5 @@
 _core:
   default_config_hash: mguGHCYb9Dw5EcpfjwoShGV1Vjkbz3QuPRCLfxiye-g
 allow_insecure_uploads: false
-default_scheme: public
+default_scheme: private
 temporary_maximum_age: 21600

--- a/config/sync/taxonomy.vocabulary.islandora_access.yml
+++ b/config/sync/taxonomy.vocabulary.islandora_access.yml
@@ -1,0 +1,8 @@
+uuid: fffefd30-6b2d-424c-9420-1ab7df0e6019
+langcode: en
+status: true
+dependencies: {  }
+name: 'Islandora Access'
+vid: islandora_access
+description: ''
+weight: 0

--- a/config/sync/views.view.media.yml
+++ b/config/sync/views.view.media.yml
@@ -1321,7 +1321,7 @@ display:
         options:
           query_comment: ''
           disable_sql_rewrite: false
-          distinct: false
+          distinct: true
           replica: false
           query_tags: {  }
       relationships:

--- a/config/sync/views.view.media_of.yml
+++ b/config/sync/views.view.media_of.yml
@@ -460,7 +460,7 @@ display:
         options:
           query_comment: ''
           disable_sql_rewrite: false
-          distinct: false
+          distinct: true
           replica: false
           query_tags: {  }
       relationships: {  }

--- a/config/sync/views.view.solr_search_content.yml
+++ b/config/sync/views.view.solr_search_content.yml
@@ -4,8 +4,10 @@ status: true
 dependencies:
   config:
     - field.storage.node.field_description
+    - field.storage.node.field_resource_type
     - search_api.index.default_solr_index
   module:
+    - group_solr
     - search_api
     - views_field_view
 _core:
@@ -753,6 +755,44 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
+        access_control_with_group_filter:
+          id: access_control_with_group_filter
+          table: views
+          field: access_control_with_group_filter
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: access_control_with_group_filter
+          operator: '='
+          value: ''
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       filter_groups:
         operator: AND
         groups:
@@ -799,7 +839,9 @@ display:
         - 'user.node_grants:view'
       tags:
         - 'config:field.storage.node.field_description'
+        - 'config:field.storage.node.field_resource_type'
         - 'config:search_api.index.default_solr_index'
+        - 'search_api_list:default_solr_index'
       cacheable: false
   block_1:
     id: block_1
@@ -900,7 +942,9 @@ display:
         - 'user.node_grants:view'
       tags:
         - 'config:field.storage.node.field_description'
+        - 'config:field.storage.node.field_resource_type'
         - 'config:search_api.index.default_solr_index'
+        - 'search_api_list:default_solr_index'
   page_1:
     id: page_1
     display_title: 'Search Page'
@@ -963,6 +1007,44 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
+        access_control_with_group_filter:
+          id: access_control_with_group_filter
+          table: views
+          field: access_control_with_group_filter
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: access_control_with_group_filter
+          operator: '='
+          value: ''
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       filter_groups:
         operator: AND
         groups:
@@ -997,5 +1079,7 @@ display:
         - 'user.node_grants:view'
       tags:
         - 'config:field.storage.node.field_description'
+        - 'config:field.storage.node.field_resource_type'
         - 'config:search_api.index.default_solr_index'
+        - 'search_api_list:default_solr_index'
       cacheable: false

--- a/config/sync/views.view.top_level_collections.yml
+++ b/config/sync/views.view.top_level_collections.yml
@@ -392,7 +392,7 @@ display:
         options:
           query_comment: ''
           disable_sql_rewrite: false
-          distinct: false
+          distinct: true
           replica: false
           query_tags: {  }
       relationships:


### PR DESCRIPTION
## About this PR: 

- Implement configurations for the Access control with Group 
- Enable private file system and switch default file system to private file system to have all assets be protected with Group
- Switch derivatives actions to private file. (ie. https://islandora.traefik.me/admin/config/system/actions/configure/image_generate_a_service_file_from_an_original_file)
- Add [a patch](https://raw.githubusercontent.com/digitalutsc/private_files_adapter/main/scripts/openseadragon.authentication.patch) to enable OpenSeadragon View include an JWT token whenever it sends a request to Cantaloupe. (Already had [a PR](https://github.com/Islandora/openseadragon/pull/40)) 

## Required modifications from isle-dc 

- Add extra steps to create a private file system directory. 
    - In isle-dc, download the Makefile's patch file at https://raw.githubusercontent.com/digitalutsc/override_permission_file_entity/main/Makefile_accesscontrol.patch
    - Apply the patch file by `patch -p1 < Makefile_accesscontrol.patch`
- In [sample.env](https://github.com/Islandora-Devops/isle-dc/blob/development/sample.env), please change:
   - `CANTALOUPE_DELEGATE_SCRIPT_ENABLED=true`
   - `CANTALOUPE_HTTPSOURCE_LOOKUP_STRATEGY=ScriptLookupStrategy`
   ==> This can prevent 403 error in OpenSeaDragon Viewer when it views an non-public image for authorized users (even with Admin users).

## Modules

### Islandora Group Module

- Module Link: https://github.com/digitalutsc/islandora_group
- Based from Danny's initial works, by tagging nodes, then it will move the node and its media into Groups, and [Group](https://www.drupal.org/project/group) will handle the access control. 
- this module will extend from Danny work to apply access control for node and media separately and provide an UI to move nodes and media to group(s)

![image](https://github.com/Islandora-Devops/islandora-starter-site/assets/7862086/2d89cd7d-9b9d-4bd1-b109-bd35f8593cc3)

![image](https://github.com/Islandora-Devops/islandora-starter-site/assets/7862086/a3a10395-e113-4469-845f-d2bd8250d25b)


### Group Solr

- Module Link: https://github.com/digitalutsc/group_solr
- Purpose: prevent restricted node(s) not being included in Search Results and Facet results counter. This ensure the accuracy for the Advanced Search module.
- Components:
    - Provide a Search API processor to check access control of nodes and media with Group when being indexed to Solr.
    - ![image](https://github.com/Islandora-Devops/islandora-starter-site/assets/7862086/d382e710-5b89-48ac-8766-90f433032a26)
    - Provide a filter in Search API Solr based View to check the access control of node when view is loading the results in Search View: https://islandora.traefik.me/admin/structure/views/view/solr_search_content (fixed the issue with search results count in View.
    - ![Screenshot 2023-07-04 at 1 47 29 PM](https://github.com/Islandora-Devops/islandora-starter-site/assets/7862086/2c9565c5-82ba-423e-a381-50f1aea2f3b5)


### Private File Adapter

- Module Link: https://github.com/digitalutsc/private_files_adapter
- Implement hook_file_access to check access control in private file when Drupal  received the requests from Cantaloupe server. 

## For ingesting Sample content with Workbench

### Requirements:

To ingest node and media with access control with Islandora Workbench:

- After the build completed, visit https://islandora.traefik.me/admin/group and create a new Group. 
- In https://islandora.traefik.me/admin/structure/taxonomy/manage/islandora_access/overview, obtain the term ID 
- In the [Spreadsheet](https://docs.google.com/spreadsheets/d/1DV0Ka0ZafZq3RgCn0x_AetFtlmnMuNFltzck2QL0ApY/edit?usp=sharing), Add column called `field_access_terms`, and paste term ID of that Term associated with that newly created Group.
- In Islandora Workbench [workbench_utils.py](https://github.com/mjordan/islandora_workbench/blob/main/workbench_utils.py), please add the follwing code **after** [line 3165](https://github.com/mjordan/islandora_workbench/blob/main/workbench_utils.py#L3165) and [line 3191](https://github.com/mjordan/islandora_workbench/blob/main/workbench_utils.py#L3191) 

````
                "field_access_terms": [{
                    "target_id": 55,
                    "target_type": 'taxonomy_term'
                }]
````
Note: Replace `55` with the tid of term associated with newly created Group

## Further development

- Currently derivatives are not automatically moved to the group(s) of their parent node.
- Restricted content's thumbnail not loading in Mirador https://github.com/digitalutsc/islandora_mirador/issues/8