### PR TITLE
Disable Member Of facet on collection search.

### DIFF
--- a/config/sync/block.block.memberofswc.yml
+++ b/config/sync/block.block.memberofswc.yml
@@ -1,6 +1,6 @@
 uuid: 76251eb7-dc58-4076-817b-6728621a517c
 langcode: en
-status: true
+status: false
 dependencies:
   config:
     - facets.facet.member_of_swc


### PR DESCRIPTION
Ticket: https://github.com/LEAF-VRE/islandora-UX-useathon/issues/12

This hides the block that shows the "Member of" facet on collection search because it is mostly redundant.

A use case for this facet would be many nested collections, but right now its presence - especially with the demo content - is more useless than useful so this PR hides the block (without removing the facet altogether in case someone wants to use it for their data). 

