### PR TITLE
Rename "Linked Agent" to "Contributors"

### DIFF
--- a/config/sync/field.field.node.islandora_object.field_linked_agent.yml
+++ b/config/sync/field.field.node.islandora_object.field_linked_agent.yml
@@ -16,7 +16,7 @@ id: node.islandora_object.field_linked_agent
 field_name: field_linked_agent
 entity_type: node
 bundle: islandora_object
-label: 'Linked Agent'
+label: 'Contributors'
 description: "Names of entities having some relationship to the resource, and, optionally, the relationship to the resource. If a relationship is not specified, it will be recorded as <a href=\"https://id.loc.gov/vocabulary/relators/asn.html\">Associated Name</a> in the system's linked data representation. <br /> \r\n<em>Publisher/manufacturer/distributor/etc. name is recorded here, with the appropriate relationship specified.</em><br />\r\nThis field does not allow creating names of entities on the fly. First create a <a href=\"/admin/structure/taxonomy/manage/person/add\" target=\"_blank\">person</a>, <a href=\"/admin/structure/taxonomy/manage/family/add\" target=\"_blank\">family</a>, or <a href=\"/admin/structure/taxonomy/manage/corporate_body/add\" target=\"_blank\">corporate body</a>, then link it here."
 required: false
 translatable: false


### PR DESCRIPTION
As discussed at the MIG meeting, August 28 2023;

Per: https://github.com/LEAF-VRE/islandora-UX-useathon/issues/14

We had more-or-less consensus that "Contributors" would be broad enough to cover this and be understandable by lay people as well as metadata professionals.

We will also mention in the release notes that this can be changed at will for your own site, and that it is one setting that applies to all objects regardless of collections.