### PR TITLE
Open advanced Views tab by default.

### DIFF
--- a/config/sync/views.settings.yml
+++ b/config/sync/views.settings.yml
@@ -7,7 +7,7 @@ sql_signature: false
 ui:
   show:
     additional_queries: false
-    advanced_column: false
+    advanced_column: true
     default_display: false
     performance_statistics: false
     preview_information: true


### PR DESCRIPTION
Opening the advanced tab in Views all the time is annoying and in managing an Islandora, you often need to do advanced views magic. This enables the setting to have the Advanced tab open by default. I often forget the option is there.

<img width="926" alt="Screenshot 2023-10-26 at 11 27 56 AM" src="https://github.com/Islandora-Devops/islandora-starter-site/assets/1943338/e67f5b13-e0b3-4838-953b-7a887133319d">



