### PR TITLE
Add the "Fast Permissions Administration" (`fpa`) module.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,7 @@
         "drupal/field_permissions": "^1",
         "drupal/field_report": "^2.1",
         "drupal/flysystem": "^2.0@alpha",
+        "drupal/fpa": "^4.0",
         "drupal/hal": "^1.0||^2.0",
         "drupal/islandora": "^2.8.1",
         "drupal/matomo": "^1.19",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5062910e4ed87591b833f10c8620e0f5",
+    "content-hash": "43f53caf075c10fa7c8fb4f2a9e66ab0",
     "packages": [
         {
             "name": "academicpuma/citeproc-php",
@@ -3431,6 +3431,62 @@
             "homepage": "https://www.drupal.org/project/flysystem",
             "support": {
                 "source": "https://git.drupalcode.org/project/flysystem"
+            }
+        },
+        {
+            "name": "drupal/fpa",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/fpa.git",
+                "reference": "4.0.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/fpa-4.0.0.zip",
+                "reference": "4.0.0",
+                "shasum": "889bc7a4c65fa435da61c6583e1aa4d29b1802e1"
+            },
+            "require": {
+                "drupal/core": "^9.4 || ^10.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "4.0.0",
+                    "datestamp": "1672325749",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "azovsky",
+                    "homepage": "https://www.drupal.org/user/330533"
+                },
+                {
+                    "name": "corey.aufang",
+                    "homepage": "https://www.drupal.org/user/163737"
+                },
+                {
+                    "name": "HakS",
+                    "homepage": "https://www.drupal.org/user/1815198"
+                },
+                {
+                    "name": "VladimirAus",
+                    "homepage": "https://www.drupal.org/user/673120"
+                }
+            ],
+            "description": "Fast filtering on permissions administration form.",
+            "homepage": "https://www.drupal.org/project/fpa",
+            "support": {
+                "source": "https://git.drupalcode.org/project/fpa"
             }
         },
         {

--- a/config/sync/block.block.creatorsandcontributors.yml
+++ b/config/sync/block.block.creatorsandcontributors.yml
@@ -47,11 +47,3 @@ visibility:
     negate: false
     view_inclusion:
       view-solr_search_content-page_1: view-solr_search_content-page_1
-  context:
-    id: context
-    negate: null
-    values: ''
-  context_all:
-    id: context_all
-    negate: null
-    values: ''

--- a/config/sync/block.block.creatorsandcontributors_swc.yml
+++ b/config/sync/block.block.creatorsandcontributors_swc.yml
@@ -35,10 +35,6 @@ visibility:
       own_page_true: '0'
       field_value: '0'
     user_fields: uid
-  context:
-    id: context
-    negate: null
-    values: ''
   context_all:
     id: context_all
     negate: null

--- a/config/sync/block.block.memberof.yml
+++ b/config/sync/block.block.memberof.yml
@@ -24,10 +24,6 @@ settings:
   context_mapping: {  }
   block_id: memberof
 visibility:
-  context:
-    id: context
-    negate: null
-    values: ''
   user_status:
     id: user_status
     negate: false
@@ -39,10 +35,6 @@ visibility:
       own_page_true: '0'
       field_value: '0'
     user_fields: uid
-  context_all:
-    id: context_all
-    negate: null
-    values: ''
   media_source_mimetype:
     id: media_source_mimetype
     negate: false

--- a/config/sync/block.block.memberofswc.yml
+++ b/config/sync/block.block.memberofswc.yml
@@ -35,10 +35,6 @@ visibility:
       own_page_true: '0'
       field_value: '0'
     user_fields: uid
-  context:
-    id: context
-    negate: null
-    values: ''
   context_all:
     id: context_all
     negate: null

--- a/config/sync/block.block.physicalform.yml
+++ b/config/sync/block.block.physicalform.yml
@@ -42,14 +42,6 @@ visibility:
     negate: false
     view_inclusion:
       view-solr_search_content-page_1: view-solr_search_content-page_1
-  context:
-    id: context
-    negate: null
-    values: ''
-  context_all:
-    id: context_all
-    negate: null
-    values: ''
   media_source_mimetype:
     id: media_source_mimetype
     negate: false

--- a/config/sync/block.block.physicalformswc.yml
+++ b/config/sync/block.block.physicalformswc.yml
@@ -35,10 +35,6 @@ visibility:
       own_page_true: '0'
       field_value: '0'
     user_fields: uid
-  context:
-    id: context
-    negate: null
-    values: ''
   context_all:
     id: context_all
     negate: null

--- a/config/sync/block.block.resource_type_swc.yml
+++ b/config/sync/block.block.resource_type_swc.yml
@@ -35,10 +35,6 @@ visibility:
       own_page_true: '0'
       field_value: '0'
     user_fields: uid
-  context:
-    id: context
-    negate: null
-    values: ''
   context_all:
     id: context_all
     negate: null

--- a/config/sync/block.block.resourcetype.yml
+++ b/config/sync/block.block.resourcetype.yml
@@ -24,10 +24,6 @@ settings:
   context_mapping: {  }
   block_id: resourcetype
 visibility:
-  context:
-    id: context
-    negate: null
-    values: ''
   user_status:
     id: user_status
     negate: false
@@ -39,10 +35,6 @@ visibility:
       own_page_true: '0'
       field_value: '0'
     user_fields: uid
-  context_all:
-    id: context_all
-    negate: null
-    values: ''
   media_source_mimetype:
     id: media_source_mimetype
     negate: false

--- a/config/sync/block.block.search.yml
+++ b/config/sync/block.block.search.yml
@@ -37,14 +37,6 @@ visibility:
       own_page_true: '0'
       field_value: '0'
     user_fields: uid
-  context:
-    id: context
-    negate: null
-    values: ''
-  context_all:
-    id: context_all
-    negate: null
-    values: ''
   media_source_mimetype:
     id: media_source_mimetype
     negate: false

--- a/config/sync/block.block.solrsearchcontentadvancedsearchforblock.yml
+++ b/config/sync/block.block.solrsearchcontentadvancedsearchforblock.yml
@@ -36,10 +36,6 @@ visibility:
       own_page_true: '0'
       field_value: '0'
     user_fields: uid
-  context:
-    id: context
-    negate: null
-    values: ''
   context_all:
     id: context_all
     negate: null

--- a/config/sync/block.block.solrsearchcontentadvancedsearchforpage.yml
+++ b/config/sync/block.block.solrsearchcontentadvancedsearchforpage.yml
@@ -36,14 +36,6 @@ visibility:
       own_page_true: '0'
       field_value: '0'
     user_fields: uid
-  context:
-    id: context
-    negate: null
-    values: ''
-  context_all:
-    id: context_all
-    negate: null
-    values: ''
   media_source_mimetype:
     id: media_source_mimetype
     negate: false

--- a/config/sync/block.block.solrsearchcontentsearchresultspagerforblock.yml
+++ b/config/sync/block.block.solrsearchcontentsearchresultspagerforblock.yml
@@ -31,10 +31,6 @@ visibility:
       own_page_true: '0'
       field_value: '0'
     user_fields: uid
-  context:
-    id: context
-    negate: null
-    values: ''
   context_all:
     id: context_all
     negate: null

--- a/config/sync/block.block.solrsearchcontentsearchresultspagerforpage.yml
+++ b/config/sync/block.block.solrsearchcontentsearchresultspagerforpage.yml
@@ -36,14 +36,6 @@ visibility:
     negate: false
     view_inclusion:
       view-solr_search_content-page_1: view-solr_search_content-page_1
-  context:
-    id: context
-    negate: null
-    values: ''
-  context_all:
-    id: context_all
-    negate: null
-    values: ''
   media_source_mimetype:
     id: media_source_mimetype
     negate: false

--- a/config/sync/block.block.subject.yml
+++ b/config/sync/block.block.subject.yml
@@ -42,14 +42,6 @@ visibility:
     negate: false
     view_inclusion:
       view-solr_search_content-page_1: view-solr_search_content-page_1
-  context:
-    id: context
-    negate: null
-    values: ''
-  context_all:
-    id: context_all
-    negate: null
-    values: ''
   media_source_mimetype:
     id: media_source_mimetype
     negate: false

--- a/config/sync/block.block.subjectname.yml
+++ b/config/sync/block.block.subjectname.yml
@@ -42,14 +42,6 @@ visibility:
     negate: false
     view_inclusion:
       view-solr_search_content-page_1: view-solr_search_content-page_1
-  context:
-    id: context
-    negate: null
-    values: ''
-  context_all:
-    id: context_all
-    negate: null
-    values: ''
   media_source_mimetype:
     id: media_source_mimetype
     negate: false

--- a/config/sync/block.block.subjectnamesswc.yml
+++ b/config/sync/block.block.subjectnamesswc.yml
@@ -35,10 +35,6 @@ visibility:
       own_page_true: '0'
       field_value: '0'
     user_fields: uid
-  context:
-    id: context
-    negate: null
-    values: ''
   context_all:
     id: context_all
     negate: null

--- a/config/sync/block.block.subjectsswc.yml
+++ b/config/sync/block.block.subjectsswc.yml
@@ -35,10 +35,6 @@ visibility:
       own_page_true: '0'
       field_value: '0'
     user_fields: uid
-  context:
-    id: context
-    negate: null
-    values: ''
   context_all:
     id: context_all
     negate: null

--- a/config/sync/block.block.subjecttemporalswc.yml
+++ b/config/sync/block.block.subjecttemporalswc.yml
@@ -35,10 +35,6 @@ visibility:
       own_page_true: '0'
       field_value: '0'
     user_fields: uid
-  context:
-    id: context
-    negate: null
-    values: ''
   context_all:
     id: context_all
     negate: null

--- a/config/sync/block.block.temporalsubject.yml
+++ b/config/sync/block.block.temporalsubject.yml
@@ -42,14 +42,6 @@ visibility:
     negate: false
     view_inclusion:
       view-solr_search_content-page_1: view-solr_search_content-page_1
-  context:
-    id: context
-    negate: null
-    values: ''
-  context_all:
-    id: context_all
-    negate: null
-    values: ''
   media_source_mimetype:
     id: media_source_mimetype
     negate: false

--- a/config/sync/block.block.views_block__solr_search_content_block_1.yml
+++ b/config/sync/block.block.views_block__solr_search_content_block_1.yml
@@ -35,10 +35,6 @@ visibility:
       own_page_true: '0'
       field_value: '0'
     user_fields: uid
-  context:
-    id: context
-    negate: null
-    values: ''
   context_all:
     id: context_all
     negate: null

--- a/config/sync/block.block.year.yml
+++ b/config/sync/block.block.year.yml
@@ -24,10 +24,6 @@ settings:
   context_mapping: {  }
   block_id: year
 visibility:
-  context:
-    id: context
-    negate: null
-    values: ''
   user_status:
     id: user_status
     negate: false
@@ -39,10 +35,6 @@ visibility:
       own_page_true: '0'
       field_value: '0'
     user_fields: uid
-  context_all:
-    id: context_all
-    negate: null
-    values: ''
   media_source_mimetype:
     id: media_source_mimetype
     negate: false

--- a/config/sync/block.block.yearswc.yml
+++ b/config/sync/block.block.yearswc.yml
@@ -35,10 +35,6 @@ visibility:
       own_page_true: '0'
       field_value: '0'
     user_fields: uid
-  context:
-    id: context
-    negate: null
-    values: ''
   context_all:
     id: context_all
     negate: null

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -45,6 +45,7 @@ module:
   filehash: 0
   filter: 0
   flysystem: 0
+  fpa: 0
   geolocation: 0
   hal: 0
   help: 0


### PR DESCRIPTION
Yesterday at the LAC-GLAM interest group, Jess Colati pointed out there's a module that lets you control, rather than be overwhelmed by, the permissions matrix. It adds a module filter-like UI with different tabs per module, as well as the ability to narrow down the roles you want to see and filter by whether those permissions are granted or not granted to those roles.

This PR adds the module.

My config export (on a brand new clean starter site) also included a bunch of removals of `context` and `context_all` blocks from the `visibility` sections of blocks. This looks perfectly innocuous to me, because they have no values. 

<img width="1500" alt="Screenshot 2024-02-02 at 9 35 53 AM" src="https://github.com/Islandora-Devops/islandora-starter-site/assets/1943338/74ee1118-2c87-41cf-8a9b-c2cabe1ad510">
