### PR TITLE
Change the thumbnail display for image media to not use image styles.

### DIFF
--- a/config/sync/core.entity_view_display.media.image.thumbnail.yml
+++ b/config/sync/core.entity_view_display.media.image.thumbnail.yml
@@ -12,7 +12,6 @@ dependencies:
     - field.field.media.image.field_mime_type
     - field.field.media.image.field_original_name
     - field.field.media.image.field_width
-    - image.style.medium
     - media.type.image
   module:
     - islandora
@@ -28,7 +27,7 @@ content:
     label: visually_hidden
     settings:
       image_link: content
-      image_style: medium
+      image_style: ''
       image_loading:
         attribute: lazy
     third_party_settings: {  }


### PR DESCRIPTION
This is a "quick fix" regarding a discussion in Slack regarding broken thumbnails caused by Drupal trying to create "Image Style" derivatives in the fedora flysystem when browsing as anonymous.

This "fix" shows thumbnail images at their original size. A [paired PR](https://github.com/Islandora-Devops/islandora_demo_objects/pull/9) resizes the Demo objects' thumbnails to be the same height (220x220) as the "medium" image style removed here.

If you are using the starter site, be aware that you should make your thumbnails "thumbnail sized". (if you use Fedora at all. Or, see below)

A better fix is for the Fedora Flysystem adapter to declare Fedora as non-writable when browsing as anonymous. Then image style derivatives should be created in public://. See issue: https://github.com/Islandora/documentation/issues/2282

This is a quick fix in anticipation of someone with the capabilities of tackling the solution above.