### PR TITLE
Add grouped filter to accommodate null external uris in model.

### DIFF
--- a/config/sync/views.view.oai_pmh.yml
+++ b/config/sync/views.view.oai_pmh.yml
@@ -163,7 +163,46 @@ display:
           plugin_id: string
           operator: '!='
           value: 'http://purl.org/dc/dcmitype/Collection'
-          group: 1
+          group: 2
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        field_external_uri_uri_1:
+          id: field_external_uri_uri_1
+          table: taxonomy_term__field_external_uri
+          field: field_external_uri_uri
+          relationship: field_model
+          group_type: group
+          admin_label: ''
+          plugin_id: string
+          operator: empty
+          value: ''
+          group: 2
           exposed: false
           expose:
             operator_id: ''
@@ -196,6 +235,7 @@ display:
         operator: AND
         groups:
           1: AND
+          2: OR
       style:
         type: default
         options:


### PR DESCRIPTION
Slack conversations:
* https://islandora.slack.com/archives/CM5PPAV28/p1706896206520609
* https://islandora.slack.com/archives/C019U12D44Q/p1707321300893149

It was found that the OAI view of MODS breaks (shows `<error code="idDoesNotExist">The value of the identifier argument is unknown or illegal in this repository.</error>`) if the object's model has no external uri. This can happen if creating custom models.

The view clearly was not meant to exclude objects with null external URI in their Model. After testing, it seems that a views filter of "value is not equal to some-string" also excludes rows where the value does not exist.

This PR adds a grouped filter so it tests if Model's external URI (is null or is not equal to `http://purl.org/dc/dcmitype/Collection`). 
<img width="1630" alt="grouped-filter" src="https://github.com/Islandora-Devops/islandora-starter-site/assets/1943338/219eb109-0b29-493e-8b74-4369e06287c6">

