### PR TITLE
Add image discovery module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "php": "^7.4 || ^8",
         "composer/installers": "^1.9",
         "cweagans/composer-patches": "^1.7",
+        "discoverygarden/dgi_image_discovery": "*",
         "drupal/admin_toolbar": "^3.1",
         "drupal/advanced_search": "^2.0.0@beta",
         "drupal/better_exposed_filters": "^6.0",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "php": "^7.4 || ^8",
         "composer/installers": "^1.9",
         "cweagans/composer-patches": "^1.7",
-        "discoverygarden/dgi_image_discovery": "*",
+        "discoverygarden/dgi_image_discovery": "^1",
         "drupal/admin_toolbar": "^3.1",
         "drupal/advanced_search": "^2.0.0@beta",
         "drupal/better_exposed_filters": "^6.0",

--- a/composer.lock
+++ b/composer.lock
@@ -1334,6 +1334,34 @@
             "time": "2022-10-27T11:44:00+00:00"
         },
         {
+            "name": "discoverygarden/dgi_image_discovery",
+            "version": "v1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/discoverygarden/dgi_image_discovery.git",
+                "reference": "145bb803cc9566876d6a5590d02d23a0cb174916"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/discoverygarden/dgi_image_discovery/zipball/145bb803cc9566876d6a5590d02d23a0cb174916",
+                "reference": "145bb803cc9566876d6a5590d02d23a0cb174916",
+                "shasum": ""
+            },
+            "require": {
+                "drupal/search_api": "^1.19"
+            },
+            "type": "drupal-module",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-3.0-only"
+            ],
+            "support": {
+                "issues": "https://github.com/discoverygarden/dgi_image_discovery/issues",
+                "source": "https://github.com/discoverygarden/dgi_image_discovery/tree/v1.0.5"
+            },
+            "time": "2023-09-22T18:14:28+00:00"
+        },
+        {
             "name": "doctrine/annotations",
             "version": "1.14.3",
             "source": {

--- a/config/sync/core.entity_view_display.node.article.default.yml
+++ b/config/sync/core.entity_view_display.node.article.default.yml
@@ -83,5 +83,6 @@ content:
     weight: 100
     region: content
 hidden:
+  did_image: true
   langcode: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.article.rss.yml
+++ b/config/sync/core.entity_view_display.node.article.rss.yml
@@ -44,6 +44,7 @@ content:
 hidden:
   body: true
   comment: true
+  did_image: true
   field_image: true
   field_tags: true
   langcode: true

--- a/config/sync/core.entity_view_display.node.article.teaser.yml
+++ b/config/sync/core.entity_view_display.node.article.teaser.yml
@@ -73,6 +73,7 @@ content:
     region: content
 hidden:
   comment: true
+  did_image: true
   field_image: true
   field_tags: true
   langcode: true

--- a/config/sync/core.entity_view_display.node.islandora_object.default.yml
+++ b/config/sync/core.entity_view_display.node.islandora_object.default.yml
@@ -424,6 +424,7 @@ content:
     weight: 9
     region: content
 hidden:
+  did_image: true
   display_media_entity_view_3: true
   display_media_thumbnail: true
   field_model: true

--- a/config/sync/core.entity_view_display.node.islandora_object.search_index.yml
+++ b/config/sync/core.entity_view_display.node.islandora_object.search_index.yml
@@ -425,6 +425,7 @@ content:
     weight: 8
     region: content
 hidden:
+  did_image: true
   display_media_entity_view_3: true
   display_media_thumbnail: true
   field_model: true

--- a/config/sync/core.entity_view_display.node.islandora_object.search_result.yml
+++ b/config/sync/core.entity_view_display.node.islandora_object.search_result.yml
@@ -162,6 +162,7 @@ content:
     weight: 11
     region: content
 hidden:
+  did_image: true
   display_media_entity_view_1: true
   display_media_entity_view_2: true
   display_media_entity_view_3: true

--- a/config/sync/core.entity_view_display.node.islandora_object.teaser.yml
+++ b/config/sync/core.entity_view_display.node.islandora_object.teaser.yml
@@ -116,6 +116,7 @@ content:
     weight: 2
     region: content
 hidden:
+  did_image: true
   display_media_entity_view_1: true
   display_media_entity_view_2: true
   display_media_original_download: true

--- a/config/sync/core.entity_view_display.node.page.default.yml
+++ b/config/sync/core.entity_view_display.node.page.default.yml
@@ -46,5 +46,6 @@ content:
     weight: 101
     region: content
 hidden:
+  did_image: true
   langcode: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.page.teaser.yml
+++ b/config/sync/core.entity_view_display.node.page.teaser.yml
@@ -48,5 +48,6 @@ content:
     weight: 101
     region: content
 hidden:
+  did_image: true
   langcode: true
   search_api_excerpt: true

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -30,6 +30,7 @@ module:
   datetime: 0
   dblog: 0
   devel: 0
+  dgi_image_discovery: 0
   dynamic_page_cache: 0
   editor: 0
   eva: 0

--- a/config/sync/field.field.node.islandora_object.field_linked_agent.yml
+++ b/config/sync/field.field.node.islandora_object.field_linked_agent.yml
@@ -35,7 +35,7 @@ settings:
     auto_create: false
     auto_create_bundle: person
   rel_types:
-    'relators:asn': ''
+    'relators:att': ''
     'relators:abr': Abridger
     'relators:act': Actor
     'relators:adp': Adapter
@@ -53,7 +53,7 @@ settings:
     'relators:art': Artist
     'relators:ard': 'Artistic director'
     'relators:asg': Assignee
-    'relators:att': 'Attributed name'
+    'relators:asn': 'Associated name'
     'relators:auc': Auctioneer
     'relators:aut': Author
     'relators:aqt': 'Author in quotations or text abstracts'

--- a/config/sync/views.view.solr_search_content.yml
+++ b/config/sync/views.view.solr_search_content.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - field.storage.node.field_description
     - field.storage.node.field_resource_type
-    - image.style.medium
     - search_api.index.default_solr_index
   module:
     - dgi_image_discovery
@@ -152,7 +151,7 @@ display:
           click_sort_column: target_id
           type: media_thumbnail
           settings:
-            image_style: medium
+            image_style: ''
             image_link: content
             image_loading:
               attribute: lazy

--- a/config/sync/views.view.solr_search_content.yml
+++ b/config/sync/views.view.solr_search_content.yml
@@ -5,10 +5,12 @@ dependencies:
   config:
     - field.storage.node.field_description
     - field.storage.node.field_resource_type
+    - image.style.medium
     - search_api.index.default_solr_index
   module:
+    - dgi_image_discovery
+    - media
     - search_api
-    - views_field_view
 _core:
   default_config_hash: d-DwLzBXnDh7as84BBK0Pxv16Ypczqg_TF9tjAyNgjU
 id: solr_search_content
@@ -97,16 +99,17 @@ display:
             use_highlighting: true
             multi_type: separator
             multi_separator: ', '
-        nid:
-          id: nid
-          table: search_api_index_default_solr_index
-          field: nid
+        did_image:
+          id: did_image
+          table: search_api_datasource_default_solr_index_entity_node
+          field: did_image
           relationship: none
           group_type: group
           admin_label: ''
-          plugin_id: search_api_field
+          entity_type: node
+          plugin_id: search_api_did_image
           label: ''
-          exclude: true
+          exclude: false
           alter:
             alter_text: false
             text: ''
@@ -146,10 +149,14 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          click_sort_column: value
-          type: number_unformatted
-          settings: {  }
-          group_column: value
+          click_sort_column: target_id
+          type: media_thumbnail
+          settings:
+            image_style: medium
+            image_link: content
+            image_loading:
+              attribute: lazy
+          group_column: target_id
           group_columns: {  }
           group_rows: true
           delta_limit: 0
@@ -158,77 +165,14 @@ display:
           delta_first_last: false
           multi_type: separator
           separator: ', '
-          field_api_classes: false
-          field_rendering: false
-          fallback_handler: search_api_numeric
+          field_api_classes: 0
+          field_rendering: 1
+          fallback_handler: search_api
           fallback_options:
-            set_precision: false
-            precision: 0
-            decimal: .
-            separator: ''
-            format_plural: false
-            format_plural_string: !!binary MQNAY291bnQ=
-            prefix: ''
-            suffix: ''
-            link_to_item: false
-            use_highlighting: false
+            link_to_item: 0
+            use_highlighting: 0
             multi_type: separator
             multi_separator: ', '
-            format_plural_values:
-              - '1'
-              - '@count'
-        view:
-          id: view
-          table: views
-          field: view
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: view
-          label: ''
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: align-right
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          view: thumbnail
-          display: block_2
-          arguments: '{{ raw_fields.nid }}'
         field_resource_type:
           id: field_resource_type
           table: search_api_index_default_solr_index

--- a/config/sync/views.view.thumbnail.yml
+++ b/config/sync/views.view.thumbnail.yml
@@ -1,6 +1,6 @@
 uuid: 3aedd62d-a991-4c64-9eb2-b0f4a8fe0a68
 langcode: en
-status: true
+status: false
 dependencies:
   config:
     - core.entity_view_mode.media.thumbnail

--- a/config/sync/views.view.thumbnail_of_first_child.yml
+++ b/config/sync/views.view.thumbnail_of_first_child.yml
@@ -1,6 +1,6 @@
 uuid: 7c122085-a727-4e49-b0b9-12d262f8f491
 langcode: en
-status: true
+status: false
 dependencies:
   module:
     - node

--- a/config/sync/views.view.top_level_collections.yml
+++ b/config/sync/views.view.top_level_collections.yml
@@ -2,8 +2,6 @@ uuid: 39576d48-0ed7-477f-be71-ad084084c19b
 langcode: en
 status: true
 dependencies:
-  config:
-    - image.style.medium
   module:
     - dgi_image_discovery
     - media
@@ -79,7 +77,7 @@ display:
           click_sort_column: target_id
           type: media_thumbnail
           settings:
-            image_style: medium
+            image_style: ''
             image_link: content
             image_loading:
               attribute: lazy

--- a/config/sync/views.view.top_level_collections.yml
+++ b/config/sync/views.view.top_level_collections.yml
@@ -2,11 +2,14 @@ uuid: 39576d48-0ed7-477f-be71-ad084084c19b
 langcode: en
 status: true
 dependencies:
+  config:
+    - image.style.medium
   module:
+    - dgi_image_discovery
+    - media
     - node
     - taxonomy
     - user
-    - views_field_view
 id: top_level_collections
 label: 'Top Level Collections'
 module: views
@@ -23,80 +26,15 @@ display:
     display_options:
       title: 'Top Level Collections'
       fields:
-        nid:
-          id: nid
-          table: node_field_data
-          field: nid
+        did_image:
+          id: did_image
+          table: node
+          field: did_image
           relationship: none
           group_type: group
           admin_label: ''
           entity_type: node
-          entity_field: nid
-          plugin_id: field
-          label: ''
-          exclude: true
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: value
-          type: number_integer
-          settings:
-            thousand_separator: ''
-            prefix_suffix: false
-          group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-        view:
-          id: view
-          table: views
-          field: view
-          relationship: none
-          group_type: group
-          admin_label: 'Thumbnail Image'
-          plugin_id: view
+          plugin_id: did_image
           label: ''
           exclude: false
           alter:
@@ -138,9 +76,23 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          view: thumbnail
-          display: block_2
-          arguments: '{{ raw_fields.nid }}'
+          click_sort_column: target_id
+          type: media_thumbnail
+          settings:
+            image_style: medium
+            image_link: content
+            image_loading:
+              attribute: lazy
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: 0
         title:
           id: title
           table: node_field_data


### PR DESCRIPTION
Added and enabled Discovery Garden's dgi image discovery module. Changed the solr and top level collections views to use this module for the thumbnail field instead of the thumbnail views. The thumbnail views were then disabled.

To test, add repository content with thumbnails that can be searched and has at least one collection and check if the thumbnails display in the search and the top level collections views.