### PR TITLE
Give Repository Item a sectioned, collapsible form.

### DIFF
--- a/config/sync/core.entity_form_display.node.islandora_object.default.yml
+++ b/config/sync/core.entity_form_display.node.islandora_object.default.yml
@@ -58,8 +58,10 @@ third_party_settings:
   field_group:
     group_structure:
       children:
-        - langcode
+        - field_member_of
         - field_weight
+        - field_viewer_override
+        - langcode
         - translation
         - path
         - status
@@ -70,7 +72,7 @@ third_party_settings:
       label: System
       region: content
       parent_name: ''
-      weight: 23
+      weight: 11
       format_type: details
       format_settings:
         classes: ''
@@ -78,56 +80,6 @@ third_party_settings:
         open: false
         description: ''
         required_fields: true
-    group_required:
-      children:
-        - title
-        - field_model
-      label: Required
-      region: content
-      parent_name: ''
-      weight: 0
-      format_type: details
-      format_settings:
-        classes: ''
-        id: ''
-        open: true
-        description: 'The title recorded here will be the main display title used within the system, and is limited to 255 characters. If your title is longer, enter a truncated version that will differentiate this resource from others in displays. Full titles longer than 255 characters may be optionally recorded below.'
-        required_fields: true
-    group_relationships:
-      children:
-        - field_member_of
-      label: Relationships
-      region: content
-      parent_name: ''
-      weight: 1
-      format_type: details
-      format_settings:
-        classes: ''
-        id: ''
-        open: false
-        description: 'Relationships between this resource and other resources'
-        required_fields: true
-        weight: 0
-        formatter: closed
-        direction: vertical
-    group_title_details:
-      children:
-        - field_full_title
-        - field_alt_title
-      label: 'Title Details'
-      region: content
-      parent_name: ''
-      weight: 2
-      format_type: details
-      format_settings:
-        classes: ''
-        id: ''
-        open: false
-        description: 'More specific title fields that are needed less frequently'
-        required_fields: true
-        weight: 0
-        formatter: closed
-        direction: vertical
     group_identifiers:
       children:
         - field_identifier
@@ -138,7 +90,7 @@ third_party_settings:
       label: Identifiers
       region: content
       parent_name: ''
-      weight: 20
+      weight: 8
       format_type: details
       format_settings:
         classes: ''
@@ -148,52 +100,41 @@ third_party_settings:
         required_fields: true
     group_publication_details:
       children:
-        - field_mode_of_issuance
-        - field_frequency
-      label: 'Publication Details'
+        - field_place_published
+        - field_place_published_country
+        - field_edtf_date_issued
+        - field_edtf_date_created
+        - field_copyright_date
+        - field_edtf_date
+        - field_edition
+        - group_issuance
+      label: 'Publication Details and Dates'
       region: content
       parent_name: ''
-      weight: 9
+      weight: 2
       format_type: details
       format_settings:
         classes: ''
+        show_empty_fields: false
         id: ''
         open: false
         description: ''
         required_fields: true
     group_additional_date_types:
       children:
-        - field_edtf_date
-        - field_copyright_date
         - field_date_valid
         - field_date_captured
         - field_date_modified
       label: 'Additional Date Types'
       region: content
       parent_name: ''
-      weight: 7
+      weight: 10
       format_type: details
       format_settings:
         classes: ''
         id: ''
         open: false
         description: 'Less-frequently needed fields for specific types of dates'
-        required_fields: true
-    group_specific_description_field:
-      children:
-        - field_abstract
-        - field_table_of_contents
-        - field_note
-      label: 'Specific Description Fields'
-      region: content
-      parent_name: ''
-      weight: 11
-      format_type: details
-      format_settings:
-        classes: ''
-        id: ''
-        open: false
-        description: 'Fields that capture description elements of specific types'
         required_fields: true
     group_classification_:
       children:
@@ -203,25 +144,7 @@ third_party_settings:
       label: 'Classification '
       region: content
       parent_name: ''
-      weight: 19
-      format_type: details
-      format_settings:
-        classes: ''
-        id: ''
-        open: false
-        description: ''
-        required_fields: true
-    group_specific_subject_types:
-      children:
-        - field_subject
-        - field_geographic_subject
-        - field_subjects_name
-        - field_temporal_subject
-        - group_geographic_coordinates
-      label: 'Specific Subject Types'
-      region: content
-      parent_name: ''
-      weight: 18
+      weight: 7
       format_type: details
       format_settings:
         classes: ''
@@ -235,11 +158,131 @@ third_party_settings:
         - field_coordinates_text
       label: 'Geographic Coordinates'
       region: content
-      parent_name: group_specific_subject_types
-      weight: 22
+      parent_name: group_subjects
+      weight: 15
       format_type: details
       format_settings:
         classes: ''
+        id: ''
+        open: false
+        description: ''
+        required_fields: true
+    group_title_and_contributors:
+      children:
+        - title
+        - field_full_title
+        - field_alt_title
+        - field_linked_agent
+      label: 'Title and Contributors'
+      region: content
+      parent_name: ''
+      weight: 1
+      format_type: details
+      format_settings:
+        classes: ''
+        show_empty_fields: true
+        id: ''
+        open: true
+        description: ''
+        required_fields: true
+    group_type_and_extent:
+      children:
+        - field_resource_type
+        - field_physical_form
+        - field_extent
+        - field_genre
+      label: 'Type and Extent'
+      region: content
+      parent_name: ''
+      weight: 4
+      format_type: details
+      format_settings:
+        classes: ''
+        show_empty_fields: true
+        id: ''
+        open: false
+        description: ''
+        required_fields: true
+    group_issuance:
+      children:
+        - field_mode_of_issuance
+        - field_frequency
+      label: Issuance
+      region: content
+      parent_name: group_publication_details
+      weight: 11
+      format_type: details
+      format_settings:
+        classes: ''
+        show_empty_fields: true
+        id: ''
+        open: false
+        description: ''
+        required_fields: true
+    group_descriptions_and_notes:
+      children:
+        - field_description
+        - field_abstract
+        - field_note
+        - field_table_of_contents
+      label: 'Descriptions and Notes'
+      region: content
+      parent_name: ''
+      weight: 5
+      format_type: details
+      format_settings:
+        classes: ''
+        show_empty_fields: true
+        id: ''
+        open: false
+        description: ''
+        required_fields: true
+    group_subjects:
+      children:
+        - field_subject_general
+        - field_subject
+        - field_subjects_name
+        - field_temporal_subject
+        - field_geographic_subject
+        - group_geographic_coordinates
+      label: Subjects
+      region: content
+      parent_name: ''
+      weight: 6
+      format_type: details
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        open: false
+        description: ''
+        required_fields: true
+    group_rights:
+      children:
+        - field_rights
+      label: Rights
+      region: content
+      parent_name: ''
+      weight: 9
+      format_type: details
+      format_settings:
+        classes: ''
+        show_empty_fields: true
+        id: ''
+        open: false
+        description: ''
+        required_fields: true
+    group_language:
+      children:
+        - field_language
+      label: Language
+      region: content
+      parent_name: ''
+      weight: 3
+      format_type: details
+      format_settings:
+        classes: ''
+        show_empty_fields: false
         id: ''
         open: false
         description: ''
@@ -253,13 +296,13 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 42
+    weight: 24
     region: content
     settings: {  }
     third_party_settings: {  }
   field_abstract:
     type: text_textarea
-    weight: 14
+    weight: 8
     region: content
     settings:
       rows: 5
@@ -267,7 +310,7 @@ content:
     third_party_settings: {  }
   field_alt_title:
     type: string_textfield
-    weight: 9
+    weight: 2
     region: content
     settings:
       size: 60
@@ -275,7 +318,7 @@ content:
     third_party_settings: {  }
   field_classification:
     type: string_textfield
-    weight: 26
+    weight: 27
     region: content
     settings:
       size: 60
@@ -297,7 +340,7 @@ content:
     third_party_settings: {  }
   field_copyright_date:
     type: edtf_default
-    weight: 14
+    weight: 8
     region: content
     settings:
       strict_dates: false
@@ -306,7 +349,7 @@ content:
     third_party_settings: {  }
   field_date_captured:
     type: edtf_default
-    weight: 17
+    weight: 15
     region: content
     settings:
       strict_dates: false
@@ -315,7 +358,7 @@ content:
     third_party_settings: {  }
   field_date_modified:
     type: edtf_default
-    weight: 18
+    weight: 17
     region: content
     settings:
       strict_dates: false
@@ -324,7 +367,7 @@ content:
     third_party_settings: {  }
   field_date_valid:
     type: edtf_default
-    weight: 16
+    weight: 14
     region: content
     settings:
       strict_dates: false
@@ -333,7 +376,7 @@ content:
     third_party_settings: {  }
   field_description:
     type: string_textarea
-    weight: 10
+    weight: 7
     region: content
     settings:
       rows: 5
@@ -349,7 +392,7 @@ content:
     third_party_settings: {  }
   field_edition:
     type: string_textfield
-    weight: 8
+    weight: 10
     region: content
     settings:
       size: 60
@@ -357,7 +400,7 @@ content:
     third_party_settings: {  }
   field_edtf_date:
     type: edtf_default
-    weight: 13
+    weight: 9
     region: content
     settings:
       strict_dates: false
@@ -366,7 +409,7 @@ content:
     third_party_settings: {  }
   field_edtf_date_created:
     type: edtf_default
-    weight: 6
+    weight: 7
     region: content
     settings:
       strict_dates: false
@@ -375,7 +418,7 @@ content:
     third_party_settings: {  }
   field_edtf_date_issued:
     type: edtf_default
-    weight: 5
+    weight: 6
     region: content
     settings:
       strict_dates: false
@@ -384,7 +427,7 @@ content:
     third_party_settings: {  }
   field_extent:
     type: string_textfield
-    weight: 16
+    weight: 11
     region: content
     settings:
       size: 60
@@ -392,7 +435,7 @@ content:
     third_party_settings: {  }
   field_frequency:
     type: entity_reference_autocomplete
-    weight: 32
+    weight: 16
     region: content
     settings:
       match_operator: CONTAINS
@@ -402,7 +445,7 @@ content:
     third_party_settings: {  }
   field_full_title:
     type: string_textarea
-    weight: 8
+    weight: 1
     region: content
     settings:
       rows: 2
@@ -410,7 +453,7 @@ content:
     third_party_settings: {  }
   field_genre:
     type: entity_reference_autocomplete
-    weight: 14
+    weight: 13
     region: content
     settings:
       match_operator: CONTAINS
@@ -420,7 +463,7 @@ content:
     third_party_settings: {  }
   field_geographic_subject:
     type: entity_reference_autocomplete
-    weight: 19
+    weight: 13
     region: content
     settings:
       match_operator: CONTAINS
@@ -482,7 +525,7 @@ content:
     third_party_settings: {  }
   field_member_of:
     type: entity_reference_autocomplete
-    weight: 33
+    weight: 14
     region: content
     settings:
       match_operator: CONTAINS
@@ -492,7 +535,7 @@ content:
     third_party_settings: {  }
   field_mode_of_issuance:
     type: entity_reference_autocomplete
-    weight: 31
+    weight: 15
     region: content
     settings:
       match_operator: CONTAINS
@@ -502,13 +545,13 @@ content:
     third_party_settings: {  }
   field_model:
     type: options_select
-    weight: 1
+    weight: 0
     region: content
     settings: {  }
     third_party_settings: {  }
   field_note:
     type: text_textarea
-    weight: 16
+    weight: 9
     region: content
     settings:
       rows: 5
@@ -524,7 +567,7 @@ content:
     third_party_settings: {  }
   field_physical_form:
     type: entity_reference_autocomplete
-    weight: 15
+    weight: 10
     region: content
     settings:
       match_operator: CONTAINS
@@ -534,7 +577,7 @@ content:
     third_party_settings: {  }
   field_pid:
     type: string_textfield
-    weight: 22
+    weight: 23
     region: content
     settings:
       size: 60
@@ -548,15 +591,25 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  field_place_published_country:
+    type: entity_reference_autocomplete
+    weight: 5
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   field_resource_type:
     type: options_select
-    weight: 13
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
   field_rights:
     type: text_textarea
-    weight: 44
+    weight: 12
     region: content
     settings:
       rows: 5
@@ -564,7 +617,7 @@ content:
     third_party_settings: {  }
   field_subject:
     type: entity_reference_autocomplete
-    weight: 18
+    weight: 10
     region: content
     settings:
       match_operator: CONTAINS
@@ -574,7 +627,7 @@ content:
     third_party_settings: {  }
   field_subject_general:
     type: entity_reference_autocomplete
-    weight: 17
+    weight: 9
     region: content
     settings:
       match_operator: CONTAINS
@@ -584,7 +637,7 @@ content:
     third_party_settings: {  }
   field_subjects_name:
     type: entity_reference_autocomplete
-    weight: 20
+    weight: 11
     region: content
     settings:
       match_operator: CONTAINS
@@ -594,7 +647,7 @@ content:
     third_party_settings: {  }
   field_table_of_contents:
     type: text_textarea
-    weight: 15
+    weight: 10
     region: content
     settings:
       rows: 5
@@ -602,7 +655,7 @@ content:
     third_party_settings: {  }
   field_temporal_subject:
     type: entity_reference_autocomplete
-    weight: 21
+    weight: 12
     region: content
     settings:
       match_operator: CONTAINS
@@ -612,47 +665,47 @@ content:
     third_party_settings: {  }
   field_viewer_override:
     type: options_select
-    weight: 22
+    weight: 16
     region: content
     settings: {  }
     third_party_settings: {  }
   field_weight:
     type: number
-    weight: 35
+    weight: 15
     region: content
     settings:
       placeholder: ''
     third_party_settings: {  }
   langcode:
     type: language_select
-    weight: 34
+    weight: 17
     region: content
     settings:
       include_locked: true
     third_party_settings: {  }
   path:
     type: path
-    weight: 37
+    weight: 20
     region: content
     settings: {  }
     third_party_settings: {  }
   promote:
     type: boolean_checkbox
-    weight: 40
+    weight: 22
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 39
+    weight: 21
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
-    weight: 43
+    weight: 25
     region: content
     settings:
       display_label: true
@@ -666,13 +719,13 @@ content:
       placeholder: ''
     third_party_settings: {  }
   translation:
-    weight: 36
+    weight: 18
     region: content
     settings: {  }
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 41
+    weight: 23
     region: content
     settings:
       match_operator: CONTAINS
@@ -680,5 +733,5 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-hidden:
-  field_place_published_country: true
+hidden: {  }
+


### PR DESCRIPTION
Because the default form is so long and it's hard to find anything, I have proposed this "collapsible form". This is a new layout for the default Repository Item form, and it puts all the fields (except Model, which is required, and at the top) into collapsible "Details" sections, and all of them (except Title And Contributors) are collapsed by default. The result is a smaller form where it is easier to get to the bottom, and hopefully easier too to find individual elements.

This has gone through the Metadata Interest Group for revision and feedback. Some, unfortunately not implemented, include:

* can we get buttons to "Expand All" / "Collapse All" ? (No, can't find any way to do this)
* can we style each field label to look the same? Currently they're only shaded/big/prominent if the field is multivalued. (Can't figure out a good way to implement CSS without our own fork of the theme). 

Here are some screenshots of the form.

<img width="770" alt="Screenshot 2024-02-26 at 4 07 44 PM" src="https://github.com/Islandora-Devops/islandora-starter-site/assets/1943338/c8b2f9ef-c369-41b2-a0ab-9d89b0eb2265">

<img width="736" alt="Screenshot 2024-02-26 at 4 07 53 PM" src="https://github.com/Islandora-Devops/islandora-starter-site/assets/1943338/2b4a2363-4c7f-4daf-8814-80c8a25cca93">

To test, spin up a starter site using this starter site fork/branch as your source. If you create or edit a repository item, you should see this form, and get no errors.