### PR TITLE
Allow Subject - Topical to create new terms.

### DIFF
--- a/config/sync/field.field.node.islandora_object.field_subject.yml
+++ b/config/sync/field.field.node.islandora_object.field_subject.yml
@@ -26,6 +26,6 @@ settings:
     sort:
       field: name
       direction: asc
-    auto_create: false
+    auto_create: true
     auto_create_bundle: subject
 field_type: entity_reference


### PR DESCRIPTION
Other Subject fields which get terms from a single vocabulary allow users to create new terms on the fly. This brings Subject - Topical (field_subject) in line with those.