### PR TITLE
Updated IIIF configs

### DIFF
--- a/config/sync/context.context.mirador_block_multipaged_items.yml
+++ b/config/sync/context.context.mirador_block_multipaged_items.yml
@@ -41,7 +41,7 @@ reactions:
         unique: 0
         context_id: mirador_block_multipaged_items
         context_mapping: {  }
-        iiif_manifest_url: '/node/[node:nid]/book-manifest-original'
+        iiif_manifest_url: '/node/[node:nid]/book-manifest'
         third_party_settings: {  }
     include_default_blocks: 1
     saved: false

--- a/config/sync/islandora_iiif.settings.yml
+++ b/config/sync/islandora_iiif.settings.yml
@@ -1,3 +1,5 @@
 _core:
   default_config_hash: NCzOnzkSw_H5SbPJb-EOzzJby1pQ8JI6IzZJckM7WOU
 iiif_server: 'https://127.0.0.1:8080/cantaloupe/iiif/2'
+use_relative_paths: false
+show_title: node


### PR DESCRIPTION
Changes the book manifest to pull service files instead of tiffs.  It's much faster.
Also added a default title for the Mirador viewer.