### PR TITLE
Use a real cache option.

### DIFF
--- a/config/sync/views.view.oai_pmh_item_data.yml
+++ b/config/sync/views.view.oai_pmh_item_data.yml
@@ -1594,7 +1594,7 @@ display:
         type: none
         options: {  }
       cache:
-        type: search_api_none
+        type: search_api_tag
         options: {  }
       empty: {  }
       sorts: {  }

--- a/config/sync/views.view.solr_search_content.yml
+++ b/config/sync/views.view.solr_search_content.yml
@@ -773,7 +773,7 @@ display:
         type: none
         options: {  }
       cache:
-        type: search_api_none
+        type: search_api_tag
         options: {  }
       empty:
         area:


### PR DESCRIPTION
We fell victim to [this bug](https://www.drupal.org/project/search_api/issues/3437379), after not thoroughly testing after running a database update. 

This PR fixes our views by using an actual caching value.

@aOelschlager for finding it.