### PR TITLE
Fix EDTF Year processor settings

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2098,17 +2098,17 @@
         },
         {
             "name": "drupal/controlled_access_terms",
-            "version": "2.4.0",
+            "version": "2.4.1",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/controlled_access_terms.git",
-                "reference": "2.4.0"
+                "reference": "2.4.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/controlled_access_terms-2.4.0.zip",
-                "reference": "2.4.0",
-                "shasum": "1b65cf1990923ae79e947d6fc16d1a056591252e"
+                "url": "https://ftp.drupal.org/files/projects/controlled_access_terms-2.4.1.zip",
+                "reference": "2.4.1",
+                "shasum": "4197c75a67c59f9f4fbac0ba03848b118f438923"
             },
             "require": {
                 "drupal/core": "^9 || ^10",
@@ -2134,8 +2134,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.4.0",
-                    "datestamp": "1711184429",
+                    "version": "2.4.1",
+                    "datestamp": "1713982994",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -12263,5 +12263,5 @@
         "php": "^7.4 || ^8"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/config/sync/search_api.index.default_solr_index.yml
+++ b/config/sync/search_api.index.default_solr_index.yml
@@ -482,10 +482,10 @@ processor_settings:
   custom_value: {  }
   edtf_year_only:
     fields:
-      islandora_object|field_copyright_date: islandora_object|field_copyright_date
-      islandora_object|field_edtf_date: islandora_object|field_edtf_date
-      islandora_object|field_edtf_date_created: islandora_object|field_edtf_date_created
-      islandora_object|field_edtf_date_issued: islandora_object|field_edtf_date_issued
+      node|islandora_object|field_copyright_date: node|islandora_object|field_copyright_date
+      node|islandora_object|field_edtf_date: node|islandora_object|field_edtf_date
+      node|islandora_object|field_edtf_date_created: node|islandora_object|field_edtf_date_created
+      node|islandora_object|field_edtf_date_issued: node|islandora_object|field_edtf_date_issued
     ignore_undated: 1
     ignore_open_start: 0
     open_start_year: '0'


### PR DESCRIPTION
Controlled_access_terms: the solr processor settings are [of a new format](https://github.com/Islandora/controlled_access_terms/blob/9c9a3f6b4c0ea2d9598092aa232a470d684f9786/src/Plugin/search_api/processor/EDTFYear.php#L142)

Without the settings changes to the new format, this will cause the processor to break and/or emit errors

## Related Links

https://github.com/Islandora/controlled_access_terms/pull/113
https://github.com/Islandora/controlled_access_terms/pull/114
https://islandora.slack.com/archives/CM5PPAV28/p1712939510602939
https://github.com/Islandora/controlled_access_terms/issues/117
