### PR TITLE
Add "Single Page Mirador Viewer" functionality, on par with OpenSeadragon.

### DIFF
--- a/config/sync/context.context.default_media_display.yml
+++ b/config/sync/context.context.default_media_display.yml
@@ -20,7 +20,7 @@ conditions:
     uuid: 79121791-57c8-47e5-89a2-27ee1884cc6e
     context_mapping:
       node: '@node.node_route_context:node'
-    uri: 'http://openseadragon.github.io,http://mozilla.github.io/pdf.js'
+    uri: 'http://openseadragon.github.io,http://mozilla.github.io/pdf.js,https://projectmirador.org'
     logic: or
 reactions:
   blocks:

--- a/config/sync/context.context.mirador_block_single_image_items.yml
+++ b/config/sync/context.context.mirador_block_single_image_items.yml
@@ -1,0 +1,48 @@
+uuid: 43fcade2-5623-483e-8a82-175dc44c5c85
+langcode: en
+status: true
+dependencies:
+  module:
+    - islandora
+    - islandora_mirador
+_core:
+  default_config_hash: sN9l77XqTzoy1x5fp1O7v91Di5_6iCx9prNHDvGYrKo
+label: 'Mirador Block - Single image items'
+name: mirador_block_single_image_items
+group: Display
+description: 'Display an image in the Mirador viewer.'
+requireAllConditions: false
+disabled: false
+conditions:
+  node_has_term:
+    id: node_has_term
+    negate: false
+    uuid: e5689bd5-7eec-4378-b329-2f35d5bb35b0
+    context_mapping:
+      node: '@node.node_route_context:node'
+    uri: 'https://projectmirador.org'
+    logic: or
+reactions:
+  blocks:
+    id: blocks
+    uuid: 50b9b25e-0836-4531-8a78-9698d71d81de
+    blocks:
+      f775e013-2400-48d4-a736-91890141dea3:
+        uuid: f775e013-2400-48d4-a736-91890141dea3
+        id: mirador_block
+        label: 'Mirador block'
+        provider: islandora_mirador
+        label_display: '0'
+        region: content_above
+        weight: '0'
+        custom_id: mirador_block
+        theme: olivero
+        css_class: ''
+        unique: 0
+        context_id: mirador_block_single_image_items
+        context_mapping: {  }
+        iiif_manifest_url: '/node/[node:nid]/manifest'
+        third_party_settings: {  }
+    include_default_blocks: 1
+    saved: false
+weight: -8

--- a/config/sync/core.entity_view_display.media.file.mirador.yml
+++ b/config/sync/core.entity_view_display.media.file.mirador.yml
@@ -1,0 +1,109 @@
+uuid: 77d02976-f471-46b4-8bf5-8c5f823971f1
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.mirador
+    - field.field.media.file.field_file_size
+    - field.field.media.file.field_height
+    - field.field.media.file.field_media_file
+    - field.field.media.file.field_media_of
+    - field.field.media.file.field_media_use
+    - field.field.media.file.field_mime_type
+    - field.field.media.file.field_original_name
+    - field.field.media.file.field_width
+    - media.type.file
+  module:
+    - file
+_core:
+  default_config_hash: xvDrCk0MLOxsyqOt9bqbAvT-qq1yONc-knLG55Rf9Aw
+id: media.file.mirador
+targetEntityType: media
+bundle: file
+mode: mirador
+content:
+  field_file_size:
+    type: number_integer
+    label: above
+    settings:
+      thousand_separator: ''
+      prefix_suffix: true
+    third_party_settings: {  }
+    weight: 5
+    region: content
+  field_gemini_uri:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 6
+    region: content
+  field_height:
+    type: number_integer
+    label: above
+    settings:
+      thousand_separator: ''
+      prefix_suffix: true
+    third_party_settings: {  }
+    weight: 5
+    region: content
+  field_media_file:
+    type: file_default
+    label: visually_hidden
+    settings:
+      use_description_as_link_text: true
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_media_of:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 4
+    region: content
+  field_media_use:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  field_mime_type:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_original_name:
+    type: basic_string
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 7
+    region: content
+  field_width:
+    type: number_integer
+    label: above
+    settings:
+      thousand_separator: ''
+      prefix_suffix: true
+    third_party_settings: {  }
+    weight: 4
+    region: content
+  name:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  created: true
+  langcode: true
+  search_api_excerpt: true
+  thumbnail: true
+  uid: true

--- a/config/sync/core.entity_view_display.media.image.mirador.yml
+++ b/config/sync/core.entity_view_display.media.image.mirador.yml
@@ -1,0 +1,113 @@
+uuid: 4e0ea14a-b44c-4f1d-8131-c3aa0fa522ed
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.mirador
+    - field.field.media.image.field_file_size
+    - field.field.media.image.field_height
+    - field.field.media.image.field_media_image
+    - field.field.media.image.field_media_of
+    - field.field.media.image.field_media_use
+    - field.field.media.image.field_mime_type
+    - field.field.media.image.field_original_name
+    - field.field.media.image.field_width
+    - image.style.max_1300x1300
+    - media.type.image
+  module:
+    - image
+_core:
+  default_config_hash: mH-3GLriL2Vx34DOnmHTqPxMCEmqJLtesug6_H_6piM
+id: media.image.mirador
+targetEntityType: media
+bundle: image
+mode: mirador
+content:
+  field_file_size:
+    type: number_integer
+    label: above
+    settings:
+      thousand_separator: ''
+      prefix_suffix: true
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  field_gemini_uri:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 9
+    region: content
+  field_height:
+    type: number_integer
+    label: above
+    settings:
+      thousand_separator: ''
+      prefix_suffix: true
+    third_party_settings: {  }
+    weight: 5
+    region: content
+  field_media_image:
+    type: image
+    label: visually_hidden
+    settings:
+      image_link: ''
+      image_style: max_1300x1300
+      image_loading:
+        attribute: lazy
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_media_of:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 6
+    region: content
+  field_media_use:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 7
+    region: content
+  field_mime_type:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_original_name:
+    type: basic_string
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 8
+    region: content
+  field_width:
+    type: number_integer
+    label: above
+    settings:
+      thousand_separator: ''
+      prefix_suffix: true
+    third_party_settings: {  }
+    weight: 4
+    region: content
+  name:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  created: true
+  langcode: true
+  search_api_excerpt: true
+  thumbnail: true
+  uid: true

--- a/config/sync/core.entity_view_mode.media.mirador.yml
+++ b/config/sync/core.entity_view_mode.media.mirador.yml
@@ -1,0 +1,11 @@
+uuid: 4d8a03d2-770b-4b14-98b8-d63d40d47849
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.mirador
+label: Mirador
+description: ''
+targetEntityType: media
+cache: true


### PR DESCRIPTION
This set of configs (thank you Mark!) sets up a context and view mode so that single paged items can be viewed in Mirador by selecting the "Viewer Override" of "Mirador".

Note that this does NOT import the "Mirador" taxonomy term as that is already done by the Islandora Mirador module in a migration that is tagged `islandora` and is therefore run during provisioning of ISLE-DC and (as of today) the Site Template.

To test:

With this PR, create an Image or Page object and set its Viewer Override to "Mirador".
Add a Service File (either by adding an Original File (Tiff or JP2 as File, or jpg/png/gif as Image) that makes derivatives, or directly). Results: The service file should display in the Mirador viewer on the node object's page. 