### PR TITLE
change so only admin can create accounts

### DIFF
--- a/config/sync/user.settings.yml
+++ b/config/sync/user.settings.yml
@@ -12,7 +12,7 @@ notify:
   register_admin_created: true
   register_no_approval_required: true
   register_pending_approval: true
-register: visitors_admin_approval
+register: admin_only
 cancel_method: user_cancel_block
 password_reset_timeout: 86400
 password_strength: true


### PR DESCRIPTION
Change the user settings so only admin can create accounts, instead of visitors being able to request accounts.

I've had a few account requests on my production sites which are most likely bots trying to find security holes.