### PR TITLE
Add Admin Toolbar Extras.

### DIFF
--- a/config/sync/admin_toolbar_search.settings.yml
+++ b/config/sync/admin_toolbar_search.settings.yml
@@ -1,0 +1,3 @@
+_core:
+  default_config_hash: AAmWcgwzGYbXfR6wfEfMyoi3r5QZwlpxvq5dHbupnJo
+display_menu_item: 0

--- a/config/sync/admin_toolbar_tools.settings.yml
+++ b/config/sync/admin_toolbar_tools.settings.yml
@@ -1,0 +1,5 @@
+_core:
+  default_config_hash: WgdZsrd_5w9jlmcHV4R9dD2tG9OZEkYo4I_O8h7Gq8Q
+max_bundle_number: 20
+hoverintent_functionality: true
+show_local_tasks: false

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -3,6 +3,9 @@ _core:
 module:
   action: 0
   admin_toolbar: 0
+  admin_toolbar_links_access_filter: 0
+  admin_toolbar_search: 0
+  admin_toolbar_tools: 0
   advanced_search: 0
   automated_cron: 0
   basic_auth: 0


### PR DESCRIPTION
As suggested by Rebel, I enabled Admin Toolbar Extras. This makes the dropdown menus behave more like they did in the ~Site Template~ Install Profile. For one, you can go to Content > Add Content > Repository Item just in the dropdown menus. You can also access Structure > Block Types. 