### PR TITLE
Add HTML title, lets you add `<i>` and `<b>` and a couple other tags to titles.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,7 @@
         "drupal/flysystem": "^2.2@alpha",
         "drupal/fpa": "^4.0",
         "drupal/hal": "^1.0||^2.0",
+        "drupal/html_title": "^1.5",
         "drupal/islandora": "^2.8.1",
         "drupal/islandora_mirador": "^2",
         "drupal/openseadragon": "^2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "58a8377f401d0f4b64c339bcb672cb1d",
+    "content-hash": "5ffd0658b69240b96aa4cc1e5fb953b0",
     "packages": [
         {
             "name": "adci/full-name-parser",
@@ -3394,6 +3394,54 @@
             "homepage": "https://www.drupal.org/project/hal",
             "support": {
                 "source": "https://git.drupalcode.org/project/hal"
+            }
+        },
+        {
+            "name": "drupal/html_title",
+            "version": "1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/html_title.git",
+                "reference": "8.x-1.5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/html_title-8.x-1.5.zip",
+                "reference": "8.x-1.5",
+                "shasum": "256ee5a97d19b2b4e5d94cb1deed47e033b3d6fd"
+            },
+            "require": {
+                "drupal/core": "^8.8 || ^9 || ^10"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.5",
+                    "datestamp": "1705876402",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "generalredneck",
+                    "homepage": "https://www.drupal.org/user/368854"
+                },
+                {
+                    "name": "JeroenT",
+                    "homepage": "https://www.drupal.org/user/2228934"
+                }
+            ],
+            "description": "Enables limited HTML markup in node titles.",
+            "homepage": "https://www.drupal.org/project/html_title",
+            "support": {
+                "source": "https://git.drupalcode.org/project/html_title"
             }
         },
         {

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -53,6 +53,7 @@ module:
   hal: 0
   help: 0
   history: 0
+  html_title: 0
   image: 0
   islandora: 0
   islandora_audio: 0

--- a/config/sync/html_title.settings.yml
+++ b/config/sync/html_title.settings.yml
@@ -1,0 +1,3 @@
+_core:
+  default_config_hash: LltQJsg3J24qmfQft-I_vH3tFvw3wAsFppnEkIvJ0oU
+allow_html_tags: '<br> <sub> <sup> <i> <b>'

--- a/config/sync/views.view.all_taxonomy_terms.yml
+++ b/config/sync/views.view.all_taxonomy_terms.yml
@@ -74,6 +74,7 @@ display:
         type: mini
         options:
           offset: 0
+          pagination_heading_level: h4
           items_per_page: 10
           total_pages: null
           id: 0
@@ -88,7 +89,6 @@ display:
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset
-          pagination_heading_level: h4
       exposed_form:
         type: basic
         options:

--- a/config/sync/views.view.archive.yml
+++ b/config/sync/views.view.archive.yml
@@ -29,6 +29,7 @@ display:
         type: mini
         options:
           offset: 0
+          pagination_heading_level: h4
           items_per_page: 10
           total_pages: 0
           id: 0
@@ -43,7 +44,6 @@ display:
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset
-          pagination_heading_level: h4
       exposed_form:
         type: basic
         options:

--- a/config/sync/views.view.block_content.yml
+++ b/config/sync/views.view.block_content.yml
@@ -273,6 +273,7 @@ display:
         type: mini
         options:
           offset: 0
+          pagination_heading_level: h4
           items_per_page: 50
           total_pages: null
           id: 0
@@ -287,7 +288,6 @@ display:
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset
-          pagination_heading_level: h4
       exposed_form:
         type: basic
         options:

--- a/config/sync/views.view.comment.yml
+++ b/config/sync/views.view.comment.yml
@@ -533,6 +533,7 @@ display:
         type: full
         options:
           offset: 0
+          pagination_heading_level: h4
           items_per_page: 50
           total_pages: null
           id: 0
@@ -550,7 +551,6 @@ display:
             offset: false
             offset_label: Offset
           quantity: 9
-          pagination_heading_level: h4
       exposed_form:
         type: basic
         options:

--- a/config/sync/views.view.content.yml
+++ b/config/sync/views.view.content.yml
@@ -585,13 +585,13 @@ display:
       pager:
         type: full
         options:
+          pagination_heading_level: h4
           items_per_page: 50
           tags:
             next: 'Next ›'
             previous: '‹ Previous'
             first: '« First'
             last: 'Last »'
-          pagination_heading_level: h4
       exposed_form:
         type: bef
         options:

--- a/config/sync/views.view.file_checksum.yml
+++ b/config/sync/views.view.file_checksum.yml
@@ -76,6 +76,7 @@ display:
         type: mini
         options:
           offset: 0
+          pagination_heading_level: h4
           items_per_page: 10
           total_pages: null
           id: 0
@@ -90,7 +91,6 @@ display:
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset
-          pagination_heading_level: h4
       exposed_form:
         type: basic
         options:

--- a/config/sync/views.view.files.yml
+++ b/config/sync/views.view.files.yml
@@ -470,6 +470,7 @@ display:
         type: mini
         options:
           offset: 0
+          pagination_heading_level: h4
           items_per_page: 50
           total_pages: 0
           id: 0
@@ -484,7 +485,6 @@ display:
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset
-          pagination_heading_level: h4
       exposed_form:
         type: basic
         options:
@@ -1055,6 +1055,7 @@ display:
         type: mini
         options:
           offset: 0
+          pagination_heading_level: h4
           items_per_page: 10
           total_pages: 0
           id: 0
@@ -1069,7 +1070,6 @@ display:
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset
-          pagination_heading_level: h4
       empty: {  }
       arguments:
         fid:

--- a/config/sync/views.view.frontpage.yml
+++ b/config/sync/views.view.frontpage.yml
@@ -30,6 +30,7 @@ display:
         type: full
         options:
           offset: 0
+          pagination_heading_level: h4
           items_per_page: 10
           total_pages: 0
           id: 0
@@ -47,7 +48,6 @@ display:
             offset: false
             offset_label: Offset
           quantity: 9
-          pagination_heading_level: h4
       exposed_form:
         type: basic
         options:

--- a/config/sync/views.view.glossary.yml
+++ b/config/sync/views.view.glossary.yml
@@ -196,6 +196,7 @@ display:
         type: mini
         options:
           offset: 0
+          pagination_heading_level: h4
           items_per_page: 36
           total_pages: 0
           id: 0
@@ -210,7 +211,6 @@ display:
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset
-          pagination_heading_level: h4
       exposed_form:
         type: basic
         options:

--- a/config/sync/views.view.iiif_manifest.yml
+++ b/config/sync/views.view.iiif_manifest.yml
@@ -166,6 +166,7 @@ display:
         type: mini
         options:
           offset: 0
+          pagination_heading_level: h4
           items_per_page: 10
           total_pages: null
           id: 0
@@ -180,7 +181,6 @@ display:
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset
-          pagination_heading_level: h4
       exposed_form:
         type: basic
         options:

--- a/config/sync/views.view.manage_members.yml
+++ b/config/sync/views.view.manage_members.yml
@@ -181,6 +181,7 @@ display:
         type: mini
         options:
           offset: 0
+          pagination_heading_level: h4
           items_per_page: 10
           total_pages: null
           id: 0
@@ -195,7 +196,6 @@ display:
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset
-          pagination_heading_level: h4
       exposed_form:
         type: basic
         options:

--- a/config/sync/views.view.media.yml
+++ b/config/sync/views.view.media.yml
@@ -785,6 +785,7 @@ display:
         type: full
         options:
           offset: 0
+          pagination_heading_level: h4
           items_per_page: 50
           total_pages: null
           id: 0
@@ -802,7 +803,6 @@ display:
             offset: false
             offset_label: Offset
           quantity: 9
-          pagination_heading_level: h4
       exposed_form:
         type: basic
         options:

--- a/config/sync/views.view.media_library.yml
+++ b/config/sync/views.view.media_library.yml
@@ -139,6 +139,7 @@ display:
         type: mini
         options:
           offset: 0
+          pagination_heading_level: h4
           items_per_page: 24
           total_pages: null
           id: 0
@@ -153,7 +154,6 @@ display:
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset
-          pagination_heading_level: h4
       exposed_form:
         type: basic
         options:

--- a/config/sync/views.view.media_of.yml
+++ b/config/sync/views.view.media_of.yml
@@ -314,6 +314,7 @@ display:
         type: mini
         options:
           offset: 0
+          pagination_heading_level: h4
           items_per_page: 10
           total_pages: null
           id: 0
@@ -328,7 +329,6 @@ display:
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset
-          pagination_heading_level: h4
       exposed_form:
         type: basic
         options:

--- a/config/sync/views.view.missing_media.yml
+++ b/config/sync/views.view.missing_media.yml
@@ -425,6 +425,7 @@ display:
         type: full
         options:
           offset: 0
+          pagination_heading_level: h4
           items_per_page: 50
           total_pages: null
           id: 0
@@ -442,7 +443,6 @@ display:
             offset: false
             offset_label: Offset
           quantity: 9
-          pagination_heading_level: h4
       exposed_form:
         type: basic
         options:

--- a/config/sync/views.view.non_fedora_files.yml
+++ b/config/sync/views.view.non_fedora_files.yml
@@ -72,6 +72,7 @@ display:
         type: mini
         options:
           offset: 0
+          pagination_heading_level: h4
           items_per_page: 10
           total_pages: null
           id: 0
@@ -86,7 +87,6 @@ display:
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset
-          pagination_heading_level: h4
       exposed_form:
         type: basic
         options:

--- a/config/sync/views.view.oai_pmh.yml
+++ b/config/sync/views.view.oai_pmh.yml
@@ -76,6 +76,7 @@ display:
         type: mini
         options:
           offset: 0
+          pagination_heading_level: h4
           items_per_page: 10
           total_pages: null
           id: 0
@@ -90,7 +91,6 @@ display:
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset
-          pagination_heading_level: h4
       exposed_form:
         type: basic
         options:
@@ -291,6 +291,7 @@ display:
         type: mini
         options:
           offset: 0
+          pagination_heading_level: h4
           items_per_page: 10
           total_pages: null
           id: 0
@@ -305,7 +306,6 @@ display:
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset
-          pagination_heading_level: h4
       style:
         type: entity_reference
         options:
@@ -332,6 +332,7 @@ display:
         type: mini
         options:
           offset: 0
+          pagination_heading_level: h4
           items_per_page: 10
           total_pages: null
           id: 0
@@ -346,7 +347,6 @@ display:
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset
-          pagination_heading_level: h4
       arguments:
         field_member_of_target_id:
           id: field_member_of_target_id
@@ -412,6 +412,7 @@ display:
         type: mini
         options:
           offset: 0
+          pagination_heading_level: h4
           items_per_page: 10
           total_pages: null
           id: 0
@@ -426,7 +427,6 @@ display:
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset
-          pagination_heading_level: h4
       filters:
         status:
           id: status

--- a/config/sync/views.view.oai_pmh_item_data.yml
+++ b/config/sync/views.view.oai_pmh_item_data.yml
@@ -20,6 +20,7 @@ dependencies:
     - search_api.index.default_solr_index
   module:
     - controlled_access_terms
+    - html_title
     - search_api
     - text
 id: oai_pmh_item_data
@@ -172,7 +173,7 @@ display:
           empty_zero: false
           hide_alter_empty: true
           click_sort_column: value
-          type: string
+          type: html_title
           settings:
             link_to_entity: false
           group_column: value
@@ -1566,6 +1567,7 @@ display:
         type: mini
         options:
           offset: 0
+          pagination_heading_level: h4
           items_per_page: 1
           total_pages: null
           id: 0
@@ -1580,7 +1582,6 @@ display:
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset
-          pagination_heading_level: h4
       exposed_form:
         type: basic
         options:

--- a/config/sync/views.view.oai_pmh_item_data.yml
+++ b/config/sync/views.view.oai_pmh_item_data.yml
@@ -156,7 +156,7 @@ display:
             more_link: false
             more_link_text: ''
             more_link_path: ''
-            strip_tags: false
+            strip_tags: true
             trim: false
             preserve_tags: ''
             html: false

--- a/config/sync/views.view.reorder_children.yml
+++ b/config/sync/views.view.reorder_children.yml
@@ -124,6 +124,7 @@ display:
         type: full
         options:
           offset: 0
+          pagination_heading_level: h4
           items_per_page: 10
           total_pages: null
           id: 0
@@ -141,7 +142,6 @@ display:
             offset: false
             offset_label: Offset
           quantity: 9
-          pagination_heading_level: h4
       exposed_form:
         type: basic
         options:

--- a/config/sync/views.view.solr_search_content.yml
+++ b/config/sync/views.view.solr_search_content.yml
@@ -744,6 +744,7 @@ display:
         type: mini
         options:
           offset: 0
+          pagination_heading_level: h4
           items_per_page: 15
           total_pages: null
           id: 0
@@ -758,7 +759,6 @@ display:
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset
-          pagination_heading_level: h4
       exposed_form:
         type: basic
         options:

--- a/config/sync/views.view.taxonomy_term.yml
+++ b/config/sync/views.view.taxonomy_term.yml
@@ -29,6 +29,7 @@ display:
         type: mini
         options:
           offset: 0
+          pagination_heading_level: h4
           items_per_page: 10
           total_pages: 0
           id: 0
@@ -43,7 +44,6 @@ display:
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset
-          pagination_heading_level: h4
       exposed_form:
         type: basic
         options:

--- a/config/sync/views.view.taxonomy_terms.yml
+++ b/config/sync/views.view.taxonomy_terms.yml
@@ -695,6 +695,7 @@ display:
         type: full
         options:
           offset: 0
+          pagination_heading_level: h4
           items_per_page: 50
           total_pages: null
           id: 0
@@ -712,7 +713,6 @@ display:
             offset: false
             offset_label: Offset
           quantity: 9
-          pagination_heading_level: h4
       exposed_form:
         type: basic
         options:

--- a/config/sync/views.view.term_from_term_name.yml
+++ b/config/sync/views.view.term_from_term_name.yml
@@ -76,6 +76,7 @@ display:
         type: mini
         options:
           offset: 0
+          pagination_heading_level: h4
           items_per_page: 10
           total_pages: null
           id: 0
@@ -90,7 +91,6 @@ display:
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset
-          pagination_heading_level: h4
       exposed_form:
         type: basic
         options:

--- a/config/sync/views.view.term_from_uri.yml
+++ b/config/sync/views.view.term_from_uri.yml
@@ -76,6 +76,7 @@ display:
         type: mini
         options:
           offset: 0
+          pagination_heading_level: h4
           items_per_page: 10
           total_pages: null
           id: 0
@@ -90,7 +91,6 @@ display:
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset
-          pagination_heading_level: h4
       exposed_form:
         type: basic
         options:

--- a/config/sync/views.view.top_level_collections.yml
+++ b/config/sync/views.view.top_level_collections.yml
@@ -160,6 +160,7 @@ display:
         type: mini
         options:
           offset: 0
+          pagination_heading_level: h4
           items_per_page: 25
           total_pages: null
           id: 0
@@ -174,7 +175,6 @@ display:
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset
-          pagination_heading_level: h4
       exposed_form:
         type: basic
         options:

--- a/config/sync/views.view.user_admin_people.yml
+++ b/config/sync/views.view.user_admin_people.yml
@@ -462,6 +462,7 @@ display:
         type: full
         options:
           offset: 0
+          pagination_heading_level: h4
           items_per_page: 50
           total_pages: 0
           id: 0
@@ -479,7 +480,6 @@ display:
             offset: false
             offset_label: Offset
           quantity: 9
-          pagination_heading_level: h4
       exposed_form:
         type: basic
         options:

--- a/config/sync/views.view.watchdog.yml
+++ b/config/sync/views.view.watchdog.yml
@@ -440,6 +440,7 @@ display:
         type: mini
         options:
           offset: 0
+          pagination_heading_level: h4
           items_per_page: 50
           total_pages: null
           id: 0
@@ -454,7 +455,6 @@ display:
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset
-          pagination_heading_level: h4
       exposed_form:
         type: basic
         options:


### PR DESCRIPTION
This PR adds the [HTML title](https://www.drupal.org/project/html_title) module. This allows you to put a short list of markup in your node titles. 

## Allowed Tags

`<br><sup><sub><i><b>`

### Why `<i>` not `<em>`?
From the [HTML reference](https://www.w3.org/TR/2012/WD-html-markup-20121025/i.html#i):

> The i element represents a span of text offset from its surrounding content without conveying any extra emphasis or importance, and for which the conventional typographic presentation is italic text; for example, a taxonomic designation, a technical term, an idiomatic phrase from another language, a thought, or a ship name.

My main use case for this improvement is taxonomic names, a frequent occurrence in theses.

### Why `<b>` not `<strong>`?
Also from the [HTML reference](https://www.w3.org/TR/2012/WD-html-markup-20121025/b.html#b):
> The b element represents a span of text offset from its surrounding content without conveying any extra emphasis or importance, and for which the conventional typographic presentation is bold text; for example, keywords in a document abstract, or product names in a review.

Reviews of books are commonly held in repositories.

### Why `<sup>` and `<sub>`?

Math and chemistry markup. However, we're not going as far as adding mathjax to titles (that'll be a recipe, since it's a little more niche).

### Why `<br>`?

I'm not sure, it came enabled. I think it's the most problematic one as the content editor has to remember to put a space on one side of the tag, or else when it gets stripped (as it does in several places, such as the tab title) you'll have words abutted against each other. It also does a poor job of signalling a subtitle since the font treatment is still h1. I'd be happy to take it out.

 
## How it works across the repository
<img width="770" alt="Screenshot 2024-08-13 at 9 50 13 AM" src="https://github.com/user-attachments/assets/e23d0c8e-a5f9-4dfe-857e-70b6312af5e1">

### Node page
Title displays in h1 with all its marked up glory, rendered nicely.

<img width="1012" alt="Screenshot 2024-08-13 at 9 50 28 AM" src="https://github.com/user-attachments/assets/efcd213d-885a-477f-a9c3-b4c2f438f787">


### Views
Content views: Title displays with html rendered nicely. Unless you strip it out with "Strip HTML tags".
<img width="1405" alt="Screenshot 2024-08-13 at 9 50 50 AM" src="https://github.com/user-attachments/assets/c51c1e61-5b30-4937-af3c-77be9160624f">

Search API views: The markup is stored in Solr. With the default "plain text" field render formatter, the raw markup is visible to the user  and "Strip HTML tags" does not work. With the alternate "HTML title text" field render formatter, the markup renders nicely in the output, encodes into XML properly (see OAI-PMH) and "Strip HTML tags" works.


### JSONLD

Markup is raw, unescaped tags in JSONLD.  I think this is okay, as the JSON-LD spec only mentions escaping HTML entities in a section specifically about embedding JSONLD into a <script> tag in HTML. Outside the HTML context, unescaped entities _should_ be fine.

<img width="873" alt="Screenshot 2024-08-13 at 10 51 12 AM" src="https://github.com/user-attachments/assets/a3eb7f0e-171a-4e98-b1b7-9a45406397d9">


### OAI-PMH
DC: The HTML is present in the XML. In a browser you see `<i>` and in a text editor you see `&lt;i&gt;`. This is correct for XML. I can't find information on whether it's ok for dublin core. PKP does not allow title italics; Omeka does. I assume it's fine. However, I think we would need to add a "strip tags" feature in code if we wanted to remove tags here.

MODS: With "plain text" as the field formatter, the HTML is doubly encoded into the XML. In a browser you see `&lt;` and in the XML in a text editor you see `&amp;lt;`.  No good!

<img width="830" alt="Screenshot 2024-08-13 at 10 37 31 AM" src="https://github.com/user-attachments/assets/be52720b-8224-4742-be5b-301cfec8137a">

This assumes harvesters can accept HTML in titles.

Otherwise, we can set the field formatter to "HTML title text" AND "Strip HTML tags" to have an HTML-less OAI experience.

### Sorting

You'll probably have a bad time if you're trying to sort on title and you have some that start with markup.