### PR TITLE
Require js_cookie for fpa

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -68,6 +68,7 @@ module:
   jquery_ui: 0
   jquery_ui_autocomplete: 0
   jquery_ui_menu: 0
+  js_cookie: 0
   jsonld: 0
   jwt: 0
   key: 0


### PR DESCRIPTION
It was made a dependency in 4.0.1: https://www.drupal.org/project/fpa/issues/3475896 i.e. https://git.drupalcode.org/project/fpa/-/merge_requests/3/diffs#b71ebb7136dbf319bd3c1a9734ed81c61c7fe4a1