### PR TITLE
Use parallel index tracker for solr

### DIFF
--- a/config/sync/search_api.index.default_solr_index.yml
+++ b/config/sync/search_api.index.default_solr_index.yml
@@ -3,43 +3,44 @@ langcode: en
 status: true
 dependencies:
   config:
+    - core.entity_view_mode.node.search_index
     - field.storage.node.field_abstract
     - field.storage.node.field_alt_title
-    - field.storage.node.field_edtf_date_created
-    - field.storage.node.field_member_of
     - field.storage.node.field_description
     - field.storage.node.field_dewey_classification
     - field.storage.node.field_edition
+    - field.storage.node.field_edtf_date_created
     - field.storage.node.field_extent
     - field.storage.node.field_full_title
+    - field.storage.node.field_geographic_subject
     - field.storage.node.field_isbn
     - field.storage.node.field_lcc_classification
     - field.storage.node.field_linked_agent
+    - field.storage.node.field_member_of
     - field.storage.node.field_oclc_number
     - field.storage.node.field_physical_form
     - field.storage.node.field_publisher
     - field.storage.node.field_resource_type
     - field.storage.node.field_rights
-    - field.storage.node.field_subject_general
-    - field.storage.node.field_geographic_subject
-    - field.storage.node.field_subjects_name
-    - field.storage.node.field_temporal_subject
     - field.storage.node.field_subject
+    - field.storage.node.field_subject_general
+    - field.storage.node.field_subjects_name
     - field.storage.node.field_tags
+    - field.storage.node.field_temporal_subject
     - search_api.server.default_solr_server
-    - core.entity_view_mode.node.search_index
   module:
-    - search_api_solr
-    - node
-    - user
-    - taxonomy
-    - search_api
     - controlled_access_terms
+    - dgi_image_discovery
+    - node
+    - search_api_solr
+    - taxonomy
+    - user
 third_party_settings:
   search_api_solr:
     finalize: false
     commit_before_finalize: false
     commit_after_finalize: false
+    debug_finalize: false
     highlighter:
       maxAnalyzedChars: 51200
       fragmenter: regex
@@ -55,11 +56,31 @@ third_party_settings:
         requireFieldMatch: false
         snippets: 3
         fragsize: 0
+    mlt:
+      mintf: 1
+      mindf: 1
+      maxdf: 0
+      maxdfpct: 0
+      minwl: 0
+      maxwl: 0
+      maxqt: 100
+      maxntp: 2000
+      boost: false
+      interestingTerms: none
+    term_modifiers:
+      slop: 3
+      fuzzy: 1
+      fuzzy_analyzer: true
     advanced:
       index_prefix: ''
+      collection: ''
+      timezone: ''
     multilingual:
+      limit_to_content_language: false
+      include_language_independent: true
       use_language_undefined_as_fallback_language: false
-      specific_languages: {  }
+      specific_languages:
+        en: '0'
       use_universal_collation: false
 _core:
   default_config_hash: 3HSYR81fyYsY--a93ZG1VSN3PEHVN_o78qIhDfsxzs4
@@ -480,6 +501,7 @@ processor_settings:
       preprocess_index: -6
       preprocess_query: -4
   custom_value: {  }
+  dgi_image_discovery: {  }
   edtf_year_only:
     fields:
       node|islandora_object|field_copyright_date: node|islandora_object|field_copyright_date
@@ -545,10 +567,11 @@ processor_settings:
     weights:
       preprocess_index: 0
 tracker_settings:
-  default:
+  index_parallel:
     indexing_order: fifo
 options:
   cron_limit: 50
+  delete_on_fail: true
   index_directly: true
   track_changes_in_references: true
 server: default_solr_server


### PR DESCRIPTION
Set the solr index tracker at `/admin/config/search/search-api/index/default_solr_index/edit` to `Index parallel` instead of `Default`. This allows the parallel solr index drush command to run with multiple threads. e.g.

```
$ drush search-api-solr:index-parallel default_solr_index \
  --threads=5 \
  --batch-size=100 \
  --uri=https://islandora.dev
```

This can significantly speed up solr re-indexing for sites with a lot of content, so it's a good base to start with. Switching the tracker from `Default -> Index parallel` after content is added causes drupal/search_api_solr to re-run the tracking on all your content; only a one time inconvenience, but still best to be avoided.

## How to test

Without this PR this command only runs with a single thread

```
$ drush search-api-solr:index-parallel default_solr_index \
  --threads=5 \
  --batch-size=100 \
  --uri=https://islandora.dev
  
 [success] Found XXXXX items to index for Default Solr content index.
 [success] Indexing parallel with 1 threads (100 items per batch run) for the index 'Default Solr content index'.
```

With this PR's config applied, the same command above allows multiple threads to run to get your content indexed

```
...
...
...
 [success] Indexing parallel with 5 threads (100 items per batch run) for the index 'Default Solr content index'.
```