### PR TITLE
Upgrade pdf.js from 2.x -> 5.x and have renovate track updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
             "type": "package",
             "package": {
                 "name": "library/pdf.js",
-                "version": "2.16.105",
+                "version": "5",
                 "type": "drupal-library",
                 "dist": {
-                    "url": "https://github.com/mozilla/pdf.js/releases/download/v2.16.105/pdfjs-2.16.105-dist.zip",
+                    "url": "https://github.com/mozilla/pdf.js/releases/download/v5.1.91/pdfjs-5.1.91-dist.zip",
                     "type": "zip"
                 }
             }
@@ -63,7 +63,7 @@
         "drush/drush": "^13",
         "islandora-rdm/islandora_fits": "dev-8.x-1.x as 1.x-dev",
         "islandora/views_nested_details": "^1.0",
-        "library/pdf.js": "^2.4",
+        "library/pdf.js": "^5",
         "mjordan/islandora_workbench_integration": "dev-main"
     },
     "conflict": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cc1071a52eee0dadf78cac795db1c18c",
+    "content-hash": "2895a10595a6ba7eba08c41d34913ea6",
     "packages": [
         {
             "name": "adci/full-name-parser",
@@ -7144,10 +7144,10 @@
         },
         {
             "name": "library/pdf.js",
-            "version": "2.16.105",
+            "version": "5",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/mozilla/pdf.js/releases/download/v2.16.105/pdfjs-2.16.105-dist.zip"
+                "url": "https://github.com/mozilla/pdf.js/releases/download/v5.1.91/pdfjs-5.1.91-dist.zip"
             },
             "type": "drupal-library"
         },

--- a/renovate.json5
+++ b/renovate.json5
@@ -5,6 +5,15 @@
   ],
   packageRules: [
     {
+      "matchDatasources": [
+        "packagist"
+      ],
+      "matchPackageNames": [
+        "library/pdf.js",
+      ],
+      "enabled": false
+    },
+    {
       matchUpdateTypes: [
         'minor',
         'patch',
@@ -28,6 +37,20 @@
       ],
       prConcurrentLimit: 1,
     },
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "composer.json"
+      ],
+      "matchStrings": [
+        "\\s+\"url\":\\s\"https:\\/\\/github.com\\/mozilla\\/pdf\\.js\\/releases\\/download\\/v(?<currentValue>.*)\\/(?:pdfjs-[^\\/]+)-dist\\.zip\"",
+      ],
+      "depNameTemplate": "mozilla/pdf.js",
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver-coerced",
+    }
   ],
   labels: [
     'dependencies',


### PR DESCRIPTION
We're a few major versions behind the current https://github.com/mozilla/pdf.js release. This PR gets us up-to-date and also configures renovate to start detecting updates for this library and issuing PRs when updates are found.