### PR TITLE
Have renovate run composer update -W

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -56,6 +56,9 @@
     'dependencies',
   ],
   osvVulnerabilityAlerts: true,
+  "postUpdateOptions": [
+    "composerWithAll"
+  ],
   dependencyDashboardOSVVulnerabilitySummary: 'unresolved',
   vulnerabilityAlerts: {
     enabled: true,


### PR DESCRIPTION
With https://github.com/renovatebot/renovate/pull/36902 merged our composer updates can now bring in dependencies by enabling the composer `-W` flag with the new [`postUpdate`](https://docs.renovatebot.com/configuration-options/#postupdateoptions) option