### PR TITLE
OAI-PMH: add node canonical URL to <dc:identifier>

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4955,17 +4955,17 @@
         },
         {
             "name": "drupal/rest_oai_pmh",
-            "version": "2.0.3",
+            "version": "2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/rest_oai_pmh.git",
-                "reference": "2.0.3"
+                "reference": "2.1.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/rest_oai_pmh-2.0.3.zip",
-                "reference": "2.0.3",
-                "shasum": "4263f1d15de76d2af76b956ba95e640b9f6a1b06"
+                "url": "https://ftp.drupal.org/files/projects/rest_oai_pmh-2.1.1.zip",
+                "reference": "2.1.1",
+                "shasum": "6f3b208e8cfd80185bfd1f797b829ad6fcedbdc5"
             },
             "require": {
                 "drupal/core": "^10.1 || ^11"
@@ -4973,8 +4973,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.0.3",
-                    "datestamp": "1754560632",
+                    "version": "2.1.1",
+                    "datestamp": "1765226908",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/config/sync/rdf.mapping.node.islandora_object.yml
+++ b/config/sync/rdf.mapping.node.islandora_object.yml
@@ -175,3 +175,9 @@ fieldMappings:
     properties:
       - 'schema:author'
     mapping_type: rel
+  nid:
+    properties:
+      - 'dcterms:identifier'
+    datatype_callback:
+      callable: 'Drupal\rest_oai_pmh\EntityUrl::makeAbsoluteUrl'
+

--- a/config/sync/rdf.mapping.node.islandora_object.yml
+++ b/config/sync/rdf.mapping.node.islandora_object.yml
@@ -180,4 +180,3 @@ fieldMappings:
       - 'dcterms:identifier'
     datatype_callback:
       callable: 'Drupal\rest_oai_pmh\EntityUrl::makeAbsoluteUrl'
-


### PR DESCRIPTION
Our DPLA contact noted our Islandora OAI-PMH endpoint was not printing the URL to the object in the metadata. The node ID seemed to be the easiest path for this, so I made [a new RDF converter in the REST OAI-PMH module](https://www.drupal.org/project/rest_oai_pmh/releases/2.1.1), which i updated in this PR. Then set `nid` in the RDF mapping to map to `<dc:identifier>`, transforming it to the absolute URL using the converter


- Before: [No node link in OAI-PMH](https://sandbox.islandora.ca/oai/request?verb=GetRecord&metadataPrefix=oai_dc&identifier=oai:sandbox.islandora.ca:node-18)
- After [Node link in `<dc:identifier>`](https://preserve.lehigh.edu/oai/request?verb=GetRecord&metadataPrefix=oai_dc&identifier=oai:preserve.lehigh.edu:node-40985)