### PR TITLE
Disable lock file maintenance in renovate config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -3,6 +3,9 @@
     'config:best-practices',
     ':rebaseStalePrs',
   ],
+  lockFileMaintenance: {
+    enabled: false,
+  },
   packageRules: [
     {
       matchDatasources: [


### PR DESCRIPTION
renovate tries bumping symfony out of bound of drupal's normal composer update process with [its lockFileMaintenance feature](https://docs.renovatebot.com/configuration-options/#lockfilemaintenance) e.g. https://github.com/Islandora-Devops/islandora-starter-site/pull/232

But that would break drupal installs so just have it stop doing it