### PR TITLE
Provide link to thumbnail in OAI-PMH

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4853,17 +4853,17 @@
         },
         {
             "name": "drupal/rest_oai_pmh",
-            "version": "2.3.0",
+            "version": "2.3.2",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/rest_oai_pmh.git",
-                "reference": "2.3.0"
+                "reference": "2.3.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/rest_oai_pmh-2.3.0.zip",
-                "reference": "2.3.0",
-                "shasum": "21e469ee0df627c33bba40dd7158b2d86c3fc870"
+                "url": "https://ftp.drupal.org/files/projects/rest_oai_pmh-2.3.2.zip",
+                "reference": "2.3.2",
+                "shasum": "d0cc6b49ee8ecfa0cdde56f73f70fbc894b96413"
             },
             "require": {
                 "drupal/core": "^10.1 || ^11"
@@ -4874,8 +4874,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.3.0",
-                    "datestamp": "1778688838",
+                    "version": "2.3.2",
+                    "datestamp": "1778704100",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/composer.lock
+++ b/composer.lock
@@ -4853,26 +4853,29 @@
         },
         {
             "name": "drupal/rest_oai_pmh",
-            "version": "2.2.1",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/rest_oai_pmh.git",
-                "reference": "2.2.1"
+                "reference": "2.3.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/rest_oai_pmh-2.2.1.zip",
-                "reference": "2.2.1",
-                "shasum": "7bf04ab655fa6017e7b01ccc6748375ab6855882"
+                "url": "https://ftp.drupal.org/files/projects/rest_oai_pmh-2.3.0.zip",
+                "reference": "2.3.0",
+                "shasum": "21e469ee0df627c33bba40dd7158b2d86c3fc870"
             },
             "require": {
                 "drupal/core": "^10.1 || ^11"
             },
+            "suggest": {
+                "discoverygarden/dgi_image_discovery": "Provides image discovery support for RDF thumbnail URL callbacks."
+            },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.2.1",
-                    "datestamp": "1771879700",
+                    "version": "2.3.0",
+                    "datestamp": "1778688838",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/config/sync/rdf.mapping.node.islandora_object.yml
+++ b/config/sync/rdf.mapping.node.islandora_object.yml
@@ -182,6 +182,6 @@ fieldMappings:
       callable: 'Drupal\rest_oai_pmh\EntityUrl::makeAbsoluteUrl'
   field_representative_image:
     properties:
-      - 'dcterms:identifier'
+      - 'dcterms:identifier.thumbnail'
     datatype_callback:
       callable: 'Drupal\rest_oai_pmh\MediaThumbnailUrl::makeAbsoluteUrl'

--- a/config/sync/rdf.mapping.node.islandora_object.yml
+++ b/config/sync/rdf.mapping.node.islandora_object.yml
@@ -180,3 +180,8 @@ fieldMappings:
       - 'dcterms:identifier'
     datatype_callback:
       callable: 'Drupal\rest_oai_pmh\EntityUrl::makeAbsoluteUrl'
+  field_representative_image:
+    properties:
+      - 'dcterms:identifier'
+    datatype_callback:
+      callable: 'Drupal\rest_oai_pmh\MediaThumbnailUrl::makeAbsoluteUrl'


### PR DESCRIPTION
Config `field_representative_media` to use new RDF data callback from https://www.drupal.org/project/rest_oai_pmh/releases/2.3.0 to print thumbnail URLs in OAI-PMH

## Testing

Bring up a site with this PR and populate it with demo objects
```
git clone https://github.com/islandora-devops/isle-site-template
cd isle-site-template
export STARTER_SITE_BRANCH=oai-pmh-thumbnail
make overwrite-starter-site up demo-objects
```

Should get a response like this
```
$ curl -s "http://islandora.io/oai/request?verb=GetRecord&identifier=oai:islandora.io:node-88&metadataPrefix=oai_dc" | xq
<?xml version="1.0"?>
<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
  <responseDate>2026-05-13T16:27:22Z</responseDate>
  <request verb="GetRecord" metadataPrefix="oai_dc">http://islandora.io/oai/request</request>
  <GetRecord>
    <record>
      <header>
        <identifier>oai:islandora.io:node-88</identifier>
        <datestamp>2026-05-13T15:28:56Z</datestamp>
        <setSpec>node:87</setSpec>
        <setSpec>oai_pmh:all_repository_items</setSpec>
      </header>
      <metadata>
        <oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
          <dc:identifier>http://islandora.io/islandora/page-1-1</dc:identifier>
          <dc:identifier.thumbnail>http://islandora.io/_flysystem/fedora/2026-05/1970_pg1.tiff_.thumbnail.jpg</dc:identifier>
          <dc:title>Page 1</dc:title>
          <dc:type>Text</dc:type>
        </oai_dc:dc>
      </metadata>
    </record>
  </GetRecord>
</OAI-PMH>
```